### PR TITLE
docs: align /docs structure with findergit-website

### DIFF
--- a/components/ShortcutsTable/ShortcutsTable.tsx
+++ b/components/ShortcutsTable/ShortcutsTable.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Group, Kbd, Table, Text } from '@mantine/core';
+
+interface Shortcut {
+  keys: string[];
+  action: string;
+}
+
+interface ShortcutsTableProps {
+  shortcuts: Shortcut[];
+}
+
+function ShortcutKeys({ keys }: { keys: string[] }) {
+  return (
+    <Group gap={4} wrap="nowrap">
+      {keys.map((key, i) => (
+        <span key={i}>
+          {i > 0 && (
+            <Text component="span" size="xs" c="dimmed" mx={2}>
+              +
+            </Text>
+          )}
+          <Kbd>{key}</Kbd>
+        </span>
+      ))}
+    </Group>
+  );
+}
+
+export function ShortcutsTable({ shortcuts }: ShortcutsTableProps) {
+  return (
+    <Table highlightOnHover>
+      <Table.Thead>
+        <Table.Tr>
+          <Table.Th w={200}>Shortcut</Table.Th>
+          <Table.Th>Action</Table.Th>
+        </Table.Tr>
+      </Table.Thead>
+      <Table.Tbody>
+        {shortcuts.map((shortcut, i) => (
+          <Table.Tr key={i}>
+            <Table.Td>
+              <ShortcutKeys keys={shortcut.keys} />
+            </Table.Td>
+            <Table.Td>{shortcut.action}</Table.Td>
+          </Table.Tr>
+        ))}
+      </Table.Tbody>
+    </Table>
+  );
+}

--- a/content/_meta.ts
+++ b/content/_meta.ts
@@ -2,7 +2,9 @@ export default {
   index: 'Introduction',
   '---': { type: 'separator' },
   'getting-started': 'Getting Started',
+  'keyboard-shortcuts': 'Keyboard Shortcuts',
+  settings: 'Settings',
   '----': { type: 'separator' },
   faq: 'FAQ',
-  'release-notes': 'Release Notes',
+  'release-notes': '',
 };

--- a/content/getting-started.mdx
+++ b/content/getting-started.mdx
@@ -51,8 +51,27 @@ Shows the selected device:
 
 The **Probe** button in the top-right of the detail header sends an ICMP ping to the device's current IPv4 and refreshes its online state immediately, instead of waiting for the next discovery pass.
 
+## Settings
+
+Open Settings with **⌘,** or from the menu **Netfox → Settings**. Five tabs:
+- **General** — theme picker (System / Light / Dark), Open at Login toggle.
+- **Alerts** — toggles for new-device + returning-after-absence alerts, plus a link to **System Settings → Notifications**.
+- **Updates** — controls for the auto-update flow (check on launch, scheduled background checks, manual *Check Now…*).
+- **Advanced** — Advanced Mode toggle, offline-detection thresholds for power users.
+- **About** — read-only version + build info.
+
+Full per-tab reference at [Settings](/docs/settings).
+
+## Updates
+
+Netfox uses a built-in auto-update framework. By default it checks once a day in the background and shows a small prompt when a newer version is available. You can also trigger a check manually from **Netfox → Check for Updates…** or from **Settings → Updates → Check for Updates Now…**.
+
 ## Tips
 
 - **⌘R** or the toolbar refresh button forces every discovery provider to emit immediately.
 - **⌘⇧A** opens **Alert History** — the persistent log of every new-device alert Netfox has ever raised.
+- **⌘⇧M** toggles **Advanced Mode** — adds the MAC to each sidebar row and surfaces the Engine ID + absolute timestamps in the detail panel. Same flag flipped from **Settings → Advanced**.
+- **⌘?** opens these docs in your browser.
 - The bell in the toolbar badges with the count of new alerts since you last opened the inbox. Tapping **Done** in the inbox clears the badge.
+
+Full keyboard reference at [Keyboard Shortcuts](/docs/keyboard-shortcuts).

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -7,17 +7,19 @@
 - **Live device list** — every machine on your network, with hostname, MAC, vendor, IPv4/IPv6, and online state
 - **Multi-source discovery** — Bonjour/mDNS, the system ARP cache, and active ICMP probing run together. Apple devices, dumb IoT, quiet hosts — all in the same list
 - **Per-device history** — first seen, last seen, every transition (online ↔ offline, IPv4 learned/changed, hostname changed, vendor learned, kind refined) on a timeline that survives across launches
-- **New-device alerts** — both as an in-app inbox (the bell in the toolbar) and as native macOS notifications. Persistent log of everything that ever fired, viewable from **View → Alert History…** (⌘⇧A)
+- **Smart alerts** — in-app inbox (the bell in the toolbar) and native macOS notifications. Fires for brand-new devices AND for known ones returning after a long absence. Persistent log viewable from **View → Alert History…** (⌘⇧A)
 - **Probe on demand** — manually re-check a specific device with **Probe This Device** from the context menu, instead of waiting for the next discovery pass
-- **Smart context menus** — copy any field, jump to history, probe a single device
+- **Manual tagging** — right-click any device to give it a custom name and icon. Useful for the cryptic vendor-name rows ("Espressif Inc.") that mean nothing without context
 - **This Mac, pinned** — the Mac running Netfox is always at the top of the sidebar, with its current Wi-Fi/Ethernet connection state
+- **Advanced Mode** (⌘⇧M) — opt-in denser UI: MAC in the sidebar, Engine ID + absolute timestamps in the detail panel
+- **Tabbed Settings** — General (theme, login), Alerts (notifications), Updates (auto-update controls), Advanced (power-user thresholds), About
 - **No account, no cloud, no telemetry** — every observation lives on your Mac
 - **Universal binary** — runs on Apple Silicon and Intel Macs; macOS picks the right slice at launch
-- **Auto-updates** — built in, signed with EdDSA
+- **Auto-updates** — built in, signed; the app checks for new versions automatically and prompts you when one is available
 
 ## Requirements
 
 - macOS 15 (Sequoia) or later
 - A local network — Wi-Fi, Ethernet, or anything macOS reports as an interface with a subnet
 
-See [Getting Started](/docs/getting-started) for first-launch notes.
+See [Getting Started](/docs/getting-started) for first-launch notes, [Settings](/docs/settings) for the full preferences reference, and [Keyboard Shortcuts](/docs/keyboard-shortcuts) for the (small) keyboard surface.

--- a/content/keyboard-shortcuts.mdx
+++ b/content/keyboard-shortcuts.mdx
@@ -1,0 +1,31 @@
+# Keyboard Shortcuts
+
+Netfox keeps the keyboard surface small on purpose — most discovery happens passively, so there's not much you need to trigger by hand. Every shortcut below either flips an app-wide mode, opens a window, or refreshes the device list.
+
+## View
+
+<ShortcutsTable shortcuts={[
+  { keys: ['⌘', 'R'], action: 'Refresh — force every discovery provider to re-emit immediately' },
+  { keys: ['⌘', '⇧', 'A'], action: 'Open Alert History — the persistent log of every alert Netfox has raised' },
+  { keys: ['⌘', '⇧', 'M'], action: 'Toggle Advanced Mode — adds MAC to the sidebar, Engine ID + absolute timestamps to the detail panel' },
+]} />
+
+## Search
+
+<ShortcutsTable shortcuts={[
+  { keys: ['⌘', 'F'], action: 'Focus the sidebar search field' },
+]} />
+
+## Application
+
+<ShortcutsTable shortcuts={[
+  { keys: ['⌘', ','], action: 'Open Settings' },
+  { keys: ['⌘', 'W'], action: 'Close the main window' },
+  { keys: ['⌘', 'Q'], action: 'Quit Netfox' },
+]} />
+
+## Help
+
+<ShortcutsTable shortcuts={[
+  { keys: ['⌘', '?'], action: 'Open the live online docs in your default browser (replaces the macOS default Help menu, which has no docs to surface)' },
+]} />

--- a/content/settings.mdx
+++ b/content/settings.mdx
@@ -1,0 +1,51 @@
+# Settings
+
+Open Settings with <Kbd>⌘</Kbd> <Kbd>,</Kbd> or from the menu **Netfox → Settings**.
+
+The window is tabbed: **General**, **Alerts**, **Updates**, **Advanced**, **About**. Every toggle takes effect immediately unless explicitly noted otherwise.
+
+## General
+
+### Appearance
+- **Theme** — System / Light / Dark. *System* follows whatever macOS is set to; *Light* and *Dark* pin Netfox regardless of the system value.
+
+### Login
+- **Open Netfox at login** — launches Netfox in the background when you log in to your Mac so it can start watching the network straight away. Off by default. Requires the signed/notarized release build to take effect — unsigned development builds can no-op silently.
+
+## Alerts
+
+### New devices
+- **Notify on new devices** — when on, Netfox raises an in-app alert (the bell in the toolbar) and a system notification whenever a previously-unknown device appears on the network.
+
+### Returning after long absence
+- **Notify when a device returns after long absence** — fires an alert when a known device that's been continuously offline for at least N days comes back online.
+- **Return threshold** — slider from 1 to 90 days (default 7). Off by default because homes with nomadic devices (phones that leave in the morning and return at night) would otherwise see this trip several times a day.
+
+### System notifications
+- **Open Notifications Settings…** — opens **System Settings → Notifications → Netfox**. Netfox uses the macOS notification center to surface alerts when the app is in the background. Grant *Allow* once and banners deliver directly; revoke any time from System Settings.
+
+## Updates
+
+### Background checks
+- **Check for updates on launch** — runs a silent check when Netfox starts. Only prompts when a newer version is available. Off by default.
+- **Automatically check for updates** — the auto-update framework's scheduled background check (every 24 hours by default). On by default. Disable if you want to freeze on your current version and check manually instead.
+
+### Manual check
+- **Check for Updates Now…** — opens the full update prompt straight away. Useful when you want to confirm you're on the latest build without waiting for the next scheduled check. Same flow as the **Netfox → Check for Updates…** menu item.
+
+## Advanced
+
+The Advanced tab consolidates every power-user knob. Visiting the tab is itself an opt-in — the controls are always rendered, under the assumption that someone who reached this tab knows what they're touching.
+
+### Application
+- **Advanced mode** — surfaces denser UI in the main window: MAC address in the sidebar secondary line, **Engine ID** copyable row in the detail Identity section, ISO 8601 absolute timestamps instead of "2 seconds ago" in the Activity section. Off by default; nothing breaks when off. Also toggleable from **View → Advanced Mode** (<Kbd>⌘</Kbd> <Kbd>⇧</Kbd> <Kbd>M</Kbd>).
+
+### Discovery — Offline detection
+- **Offline threshold** — slider from 60 to 900 seconds (default 5 min). How long a device that's only visible via the system ARP cache can stay silent before being marked offline. Affects printers, NAS, and dumb IoT that don't advertise via Bonjour.
+- **Authoritative threshold** — slider from 30 to 600 seconds (default 3 min). How long a Bonjour-visible device can go silent before being marked offline. Tighter than the ARP fallback because Bonjour can confirm liveness directly.
+
+Threshold changes take effect on the **next app launch** — the lifecycle pass and anti-thrash rule both fix their windows at engine construction.
+
+## About
+
+Shows the app icon, current version, build number, and a short tagline. Read-only.

--- a/mdx-components.ts
+++ b/mdx-components.ts
@@ -1,10 +1,12 @@
 import { Kbd } from '@mantine/core';
 import { useMDXComponents as getDocsMDXComponents } from 'nextra-theme-docs';
+import { ShortcutsTable } from '@/components/ShortcutsTable/ShortcutsTable';
 
 const docsComponents = getDocsMDXComponents();
 
 export const useMDXComponents = (components?: any): any => ({
   ...docsComponents,
   Kbd,
+  ShortcutsTable,
   ...components,
 });


### PR DESCRIPTION
## Summary

First step of the netfox-website ↔ findergit-website alignment effort. Brings the `/docs` sub-tree to structural parity with findergit-website's `/docs` shape; homepage alignment is the deliberate next step (separate PR).

## What lands

### New pages

| File | Source pattern | Adaptation |
|---|---|---|
| `content/keyboard-shortcuts.mdx` | findergit-website's same file | Netfox-specific shortcuts: ⌘R, ⌘⇧A, ⌘⇧M, ⌘F, ⌘,, ⌘W, ⌘Q, ⌘? |
| `content/settings.mdx` | findergit-website's same file | Netfox's 5 Settings tabs (General / Alerts / Updates / Advanced / About) per-tab reference |
| `components/ShortcutsTable/ShortcutsTable.tsx` | verbatim port from findergit-website | none — Mantine `Kbd` chips + Table |

### Navigation

`content/_meta.ts` adds `keyboard-shortcuts` and `settings` between `getting-started` and the FAQ separator, matching findergit-website's ordering.

### Audit refresh of existing pages

- `content/index.mdx` — "What it does" list refreshed to reflect Netfox 0.1.2 reality: smart alerts cover both new-device and return-after-absence triggers; manual tagging added; Advanced Mode mention; tabbed Settings overview. Footer adds cross-links to the new pages.
- `content/getting-started.mdx` — new **Settings** section sketches the 5 tabs and links to `/docs/settings`; new **Updates** section explains the auto-update flow; **Tips** list gains ⌘⇧M (Advanced Mode) and ⌘? (online docs), and points to the full keyboard reference.

### `mdx-components.ts`

Registers `ShortcutsTable` so MDX pages can use `<ShortcutsTable shortcuts={[...]} />` natively.

## What's NOT in this PR (deferred)

- **Netfox-specific feature pages** (`device-discovery.mdx`, `alerts.mdx`, `device-tagging.mdx`, `device-history.mdx`) — would parallel FinderGit's `file-browser`/`git-actions`/`diff-viewer`/`ai-commit-messages` pages. That's content work, not structure; will land per-feature in follow-up PRs.
- **Homepage alignment** — the user-requested next step after docs. Separate PR on a fresh branch.
- **FAQ extension** — current 9 questions cover the main concerns; auto-update / Settings questions are polish for a future content PR.

## Test plan

- [ ] Vercel preview build is green
- [ ] `netfox.app/docs` sidebar lists: Introduction → Getting Started → Keyboard Shortcuts → Settings → FAQ → Release Notes
- [ ] `/docs/keyboard-shortcuts` renders the `ShortcutsTable` with Mantine `Kbd` styling consistent with findergit.app's same page
- [ ] `/docs/settings` renders cleanly across all five sections
- [ ] Cross-links from Introduction (Settings, Keyboard Shortcuts) and Getting Started (Settings, Keyboard Shortcuts) resolve