### PR TITLE
fix(hero): use explicit DepthSelect height per docs pattern

### DIFF
--- a/components/Welcome/Welcome.tsx
+++ b/components/Welcome/Welcome.tsx
@@ -386,23 +386,24 @@ export function Welcome() {
             (4 cards) and wrapping reads less awkwardly than hitting a
             hard stop at the ends.
           */}
-          <Box
-            mt={32}
-            // The DepthSelect renders its cards `position: absolute`
-            // (so the stack overlaps in 3D). Without an explicit
-            // height the wrapper collapses to 0px and the slideshow
-            // disappears. The screenshots ship at ~3:2; reserve
-            // enough room for the front card plus the trailing
-            // visibleCards offsets (`translateYStep * (visibleCards
-            // - 1)` ≈ 90px headroom).
-            style={{
-              position: 'relative',
-              width: '100%',
-              aspectRatio: '3 / 2',
-              maxWidth: 1100,
-              marginInline: 'auto',
-            }}
-          >
+          <Box mt={32} maw={1100} mx="auto">
+            {/*
+              Follow the component's documented usage pattern:
+              numeric `h` directly on the DepthSelect (the docs
+              demo uses `h={200}`). Earlier the slideshow lived
+              inside a wrapper with `aspect-ratio` + `h="100%"`,
+              which left the controls column without a tall flex
+              container — `controlsProps.justify: 'center'` had
+              no room to centre against. With an explicit pixel
+              height the column gets its proper bounds and
+              centring works.
+
+              640 is a balanced choice: tall enough that the
+              active card preserves the screenshots' ratio on a
+              typical desktop width, short enough that the hero
+              doesn't push the next-section content past the
+              fold on a 1080p display.
+            */}
             <DepthSelect
               data={heroSlides}
               defaultValue="overview"
@@ -410,15 +411,9 @@ export function Welcome() {
               loop
               ariaLabel="Netfox screenshots"
               controlsPosition="right"
-              // The DepthSelect ships with `justify: 'start'` as
-              // the runtime default (the TS doc claims `center`
-              // but the rendered output disagrees). Force-centre
-              // the up/down controls vertically so they sit
-              // beside the active card instead of floating at
-              // the top edge of the wrapper.
-              controlsProps={{ justify: 'center' }}
-              h="100%"
+              controlsProps={{ justify: 'center', w: 80 }}
               w="100%"
+              h={640}
             />
           </Box>
         </Container>


### PR DESCRIPTION
## Summary

Wire the hero `DepthSelect` the way the component's [docs](https://gfazioli.github.io/mantine-depth-select/) demo it: numeric `h` directly on the component, `controlsProps.w` for the controls column.

### Why
We previously wrapped the slideshow in a Box with `aspect-ratio: 3/2` and passed `h="100%"` to the DepthSelect. The wrapper height was computable from the width, but inside the component's flex row the controls column was inferring its height from its own content (two buttons + gap) instead of stretching to the parent. So `controlsProps.justify: 'center'` had nothing to centre against — the up/down arrows clung to the top edge of the stack.

### After
- `h={640}` directly on DepthSelect — matches the screenshots' 16:10 ratio at the 1100px max-width hero uses on desktop, keeps the fold clear on a 1080p viewport.
- `controlsProps.w: 80` while we're here, so the controls column has a stable width across label changes.

## Test plan

- [ ] `yarn dev` → home hero — up/down arrows now sit vertically centred alongside the active card (not floating at the top edge)
- [ ] Hard-reload after Vercel deploys netfox.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)