### PR TITLE
fix(footer): point FinderGit link to findergit.app

### DIFF
--- a/components/MantineFooter/links/ecosystem.ts
+++ b/components/MantineFooter/links/ecosystem.ts
@@ -2,7 +2,7 @@ export const ecosystem = [
   {
     key: 'findergit',
     title: 'FinderGit',
-    href: 'https://findergit-website.vercel.app',
+    href: 'https://findergit.app',
     newWindow: true,
   },
   {


### PR DESCRIPTION
## Summary

The ecosystem column's **FinderGit** entry was wired to `https://findergit-website.vercel.app` — the Vercel preview URL from the first deploy. The production site lives at the custom domain `https://findergit.app/`. One-line `href` fix.

## Test plan

- [ ] After Vercel deploys, click the FinderGit link in the footer → lands on https://findergit.app/

🤖 Generated with [Claude Code](https://claude.com/claude-code)