### PR TITLE
feat(hero): add Product Hunt launch badge

### DIFF
--- a/components/Welcome/Welcome.tsx
+++ b/components/Welcome/Welcome.tsx
@@ -373,6 +373,29 @@ export function Welcome() {
                 See what it does
               </Button>
             </Group>
+
+            {/* ─── Product Hunt launch badge ─── */}
+            {/*
+              Featured badge from our Product Hunt launch. Rendered as a
+              plain anchor wrapping the Mantine Image (not next/image) so
+              the externally-hosted SVG with its cache-busting `t=` query
+              param is served as-is, untouched by Next's optimizer. Fixed
+              250×54 to match Product Hunt's canonical badge dimensions.
+            */}
+            <a
+              href="https://www.producthunt.com/products/netfox?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-netfox"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Netfox on Product Hunt"
+            >
+              <Image
+                src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1156418&theme=light&t=1779880374909"
+                alt="Netfox - A native local macOS network monitor | Product Hunt"
+                w={250}
+                h={54}
+                fit="contain"
+              />
+            </a>
           </Stack>
 
           {/* ─── Hero slideshow ─── */}


### PR DESCRIPTION
## What

Adds the Product Hunt featured badge to the homepage hero, directly under the primary CTAs (`Download for macOS` / `See what it does`) — the highest-visibility spot during launch day.

## Notes

- Rendered as a plain anchor wrapping the Mantine `Image` (not `next/image`) so the externally-hosted badge SVG — with its cache-busting `t=` query param — is served as-is, untouched by Next's optimizer.
- Fixed 250×54 to match Product Hunt's canonical badge dimensions.
- Kept `theme=light` from the embed snippet. Can switch to `theme=dark`/`theme=neutral` if we want it to blend into the dark hero rather than pop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)