### PR TITLE
fix: release notes — app-only filter + cap to 3 most recent

### DIFF
--- a/app/api/github-releases/route.ts
+++ b/app/api/github-releases/route.ts
@@ -75,9 +75,16 @@ export async function GET(request: Request) {
     }
 
     const releases = await response.json();
+    // Only Netfox app releases, capped to the most recent displayCount.
+    const prefix = config.releaseNotes.appReleaseNamePrefix;
+    const appReleases = Array.isArray(releases)
+      ? releases
+          .filter((r: any) => typeof r?.name === 'string' && r.name.startsWith(prefix))
+          .slice(0, config.releaseNotes.displayCount)
+      : releases;
 
     return Response.json(
-      { releases, status: 'ok' },
+      { releases: appReleases, status: 'ok' },
       {
         headers: {
           'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',

--- a/config/index.ts
+++ b/config/index.ts
@@ -68,6 +68,12 @@ export default {
     // "View full changelog on GitHub" button at the bottom of /docs/release-notes.
     url: 'https://github.com/gfazioli/netfox-website/releases',
     maxReleases: 10,
+    // Releases share this repo with the website's own Mantine/Nextra
+    // template releases (a `v6.x` tag on package bumps). Keep only Netfox
+    // app releases (release.sh names them "Netfox X.Y.Z"), and render just
+    // the most recent few — the rest are one click away on GitHub.
+    appReleaseNamePrefix: 'Netfox',
+    displayCount: 3,
   },
   search: {
     queryKeyword: 'q',


### PR DESCRIPTION
Pre-emptive port of findergit-website's release-notes fix (no rogue release on netfox-website **yet**, but same template + same-repo model = same latent bug). Keeps only releases named with `config.releaseNotes.appReleaseNamePrefix` ('Netfox') and caps the list to `displayCount` (3); the rest stay one click away via the changelog button. Filtered in the API route (netfox has no build-time TOC fetch, unlike findergit). `yarn build` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Notes**
  * Now displays only the main application releases, automatically filtering out other release types to reduce clutter.
  * Limited to showing the 3 most recent releases, providing a more focused and curated release history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->