### PR TITLE
feat: add "Buy me a coffee" button next to Become a sponsor

### DIFF
--- a/components/MantineFooter/MantineFooter.tsx
+++ b/components/MantineFooter/MantineFooter.tsx
@@ -5,6 +5,7 @@ import {
   IconBrandMantine,
   IconBrandVercel,
   IconBrandX,
+  IconCoffee,
   IconHeartFilled,
   IconMailHeart,
   IconPlus,
@@ -175,19 +176,36 @@ export const MantineFooter = () => {
               </Stack>
             </Anchor>
           </Group>
-          <Button
-            mb="xl"
-            component="a"
-            href="https://github.com/sponsors/gfazioli"
-            target="_blank"
-            rel="noopener noreferrer"
-            variant="gradient"
-            gradient={{ from: 'pink', to: 'grape' }}
-            leftSection={<IconHeartFilled size={16} />}
-            radius="xl"
-          >
-            Become a sponsor
-          </Button>
+          <Group mb="xl" gap="sm" justify="center">
+            <Button
+              component="a"
+              href="https://github.com/sponsors/gfazioli"
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="gradient"
+              gradient={{ from: 'pink', to: 'grape' }}
+              leftSection={<IconHeartFilled size={16} />}
+              radius="xl"
+            >
+              Become a sponsor
+            </Button>
+            <Button
+              component="a"
+              href="https://donate.stripe.com/fZu4gy4Tn3b1dgudGx0co00"
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="filled"
+              color="yellow"
+              leftSection={<IconCoffee size={16} />}
+              radius="xl"
+              styles={{
+                label: { color: 'var(--mantine-color-white)' },
+                section: { color: 'var(--mantine-color-white)' },
+              }}
+            >
+              Buy me a coffee
+            </Button>
+          </Group>
         </Stack>
 
         <Divider my={16} className={classes.lastDivider} />


### PR DESCRIPTION
Adds a one-time-donation **Buy me a coffee** button (Stripe) in the footer next to **Become a sponsor** — yellow fill, white label + icon, coffee icon. Mirrors the FinderGit site.