### PR TITLE
feat: SEO improvements — sitemap, per-page metadata, structured data, manifest

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,7 +14,7 @@ import { getPageMap } from 'nextra/page-map';
 import { ColorSchemeScript, mantineHtmlProps, MantineProvider } from '@mantine/core';
 // !! End of important imports !!
 
-import { MantineFooter, MantineNavBar } from '@/components';
+import { MantineFooter, MantineNavBar, StructuredData } from '@/components';
 import config from '@/config';
 import { theme } from '../theme';
 
@@ -33,16 +33,17 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           nonce={head.mantine.nonce}
           defaultColorScheme={head.mantine.defaultColorScheme}
         />
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
         <link rel="shortcut icon" href="/favicon.ico" />
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-        <meta
-          name="viewport"
-          content="minimum-scale=1, initial-scale=1, width=device-width, user-scalable=no"
-        />
+        <meta name="theme-color" content="#f76707" />
+        {/* Keep pinch-zoom enabled — `user-scalable=no` is an accessibility/SEO ding. */}
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
       <body>
+        <StructuredData />
         <MantineProvider theme={theme} defaultColorScheme={head.mantine.defaultColorScheme}>
           <Layout
             banner={

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,22 @@
+import type { MetadataRoute } from 'next';
+
+// Web App Manifest. Next.js serves this at /manifest.webmanifest and injects
+// the <link rel="manifest"> automatically. Gives the site a PWA identity
+// (installable, themed) and clears the corresponding Lighthouse / SEO checks.
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'Netfox — Network Monitor for macOS',
+    short_name: 'Netfox',
+    description:
+      'A native macOS app that monitors your home network — every device, when it joined, and what looks risky, at a glance.',
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#1a1b1e',
+    theme_color: '#f76707',
+    icons: [
+      { src: '/icon-192x192.png', sizes: '192x192', type: 'image/png' },
+      { src: '/icon-512x512.png', sizes: '512x512', type: 'image/png' },
+      { src: '/icon-512x512.png', sizes: '512x512', type: 'image/png', purpose: 'maskable' },
+    ],
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,56 @@
+import type { MetadataRoute } from 'next';
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Generated at build time. Enumerates the homepage plus every MDX doc under
+// content/ (served at /docs/* via Nextra's contentDirBasePath). Filesystem
+// walk rather than the Nextra page map so the output is deterministic and
+// easy to reason about — every committed .mdx becomes one entry.
+const BASE = 'https://netfox.app';
+const CONTENT_DIR = join(process.cwd(), 'content');
+
+interface DocPage {
+  route: string;
+  lastModified: Date;
+}
+
+function walk(dir: string, baseRoute: string, out: DocPage[]): void {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    // Skip Nextra meta files (_meta.tsx) and any underscore-prefixed entry.
+    if (entry.name.startsWith('_')) {
+      continue;
+    }
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, `${baseRoute}/${entry.name}`, out);
+    } else if (entry.name.endsWith('.mdx')) {
+      const slug = entry.name.replace(/\.mdx$/, '');
+      const route = slug === 'index' ? baseRoute : `${baseRoute}/${slug}`;
+      out.push({ route, lastModified: statSync(full).mtime });
+    }
+  }
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const docs: DocPage[] = [];
+  walk(CONTENT_DIR, '/docs', docs);
+
+  const entries: MetadataRoute.Sitemap = docs
+    .sort((a, b) => a.route.localeCompare(b.route))
+    .map((doc) => ({
+      url: `${BASE}${doc.route}`,
+      lastModified: doc.lastModified,
+      changeFrequency: 'monthly',
+      priority: doc.route === '/docs' ? 0.8 : 0.7,
+    }));
+
+  // Homepage first, highest priority.
+  entries.unshift({
+    url: `${BASE}/`,
+    lastModified: new Date(),
+    changeFrequency: 'weekly',
+    priority: 1,
+  });
+
+  return entries;
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,12 +1,13 @@
 import type { MetadataRoute } from 'next';
 import { readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+import config from '@/config';
 
 // Generated at build time. Enumerates the homepage plus every MDX doc under
 // content/ (served at /docs/* via Nextra's contentDirBasePath). Filesystem
 // walk rather than the Nextra page map so the output is deterministic and
 // easy to reason about — every committed .mdx becomes one entry.
-const BASE = 'https://netfox.app';
+const BASE = config.metadata.metadataBase.toString().replace(/\/$/, '');
 const CONTENT_DIR = join(process.cwd(), 'content');
 
 interface DocPage {

--- a/components/StructuredData/StructuredData.tsx
+++ b/components/StructuredData/StructuredData.tsx
@@ -4,7 +4,9 @@ import config from '@/config';
 // site eligible for Google's app rich results; Organization + WebSite anchor
 // the brand entity. Values are sourced from config so version/description stay
 // in sync with the rest of the site.
-const BASE = 'https://netfox.app';
+// Single source of truth — derived from the canonical metadataBase so the
+// JSON-LD URLs can't drift from the rest of the site's metadata.
+const BASE = config.metadata.metadataBase.toString().replace(/\/$/, '');
 
 const structuredData = {
   '@context': 'https://schema.org',

--- a/components/StructuredData/StructuredData.tsx
+++ b/components/StructuredData/StructuredData.tsx
@@ -1,0 +1,54 @@
+import config from '@/config';
+
+// schema.org JSON-LD injected site-wide. A SoftwareApplication node makes the
+// site eligible for Google's app rich results; Organization + WebSite anchor
+// the brand entity. Values are sourced from config so version/description stay
+// in sync with the rest of the site.
+const BASE = 'https://netfox.app';
+
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'SoftwareApplication',
+      '@id': `${BASE}/#app`,
+      name: 'Netfox',
+      applicationCategory: 'UtilitiesApplication',
+      operatingSystem: `macOS ${config.app.minMacOS} or later`,
+      description: config.metadata.description,
+      url: BASE,
+      downloadUrl: config.app.downloadUrl,
+      softwareVersion: config.app.version,
+      screenshot: `${BASE}/screenshot-overview.png`,
+      offers: {
+        '@type': 'Offer',
+        price: '0',
+        priceCurrency: 'USD',
+      },
+      publisher: { '@id': `${BASE}/#org` },
+    },
+    {
+      '@type': 'Organization',
+      '@id': `${BASE}/#org`,
+      name: 'Netfox',
+      url: BASE,
+      logo: `${BASE}/icon-512x512.png`,
+    },
+    {
+      '@type': 'WebSite',
+      '@id': `${BASE}/#website`,
+      name: 'Netfox',
+      url: BASE,
+      publisher: { '@id': `${BASE}/#org` },
+    },
+  ],
+};
+
+export function StructuredData() {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+    />
+  );
+}

--- a/components/index.ts
+++ b/components/index.ts
@@ -4,3 +4,4 @@ export { Logo } from './Logo/Logo';
 export { MantineFooter } from './MantineFooter/MantineFooter';
 export { MantineNavBar } from './MantineNavBar/MantineNavBar';
 export { MantineNextraThemeObserver } from './MantineNextraThemeObserver/MantineNextraThemeObserver';
+export { StructuredData } from './StructuredData/StructuredData';

--- a/content/faq.mdx
+++ b/content/faq.mdx
@@ -1,3 +1,8 @@
+---
+title: "FAQ"
+description: "Common Netfox questions answered: pricing, privacy, supported macOS versions, how device discovery works, permissions and updates."
+---
+
 # FAQ
 
 <div style={{ marginTop: 32 }} />

--- a/content/getting-started.mdx
+++ b/content/getting-started.mdx
@@ -1,3 +1,8 @@
+---
+title: "Getting Started"
+description: "Install Netfox and see every device on your macOS network in under a minute — the first-launch walkthrough, permissions and first scan."
+---
+
 import { Callout } from 'nextra/components';
 
 # Getting Started

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -1,3 +1,8 @@
+---
+title: "Documentation"
+description: "How Netfox monitors your macOS home network: the five tools, device discovery, alerts, security checks and the menu bar. Start here."
+---
+
 import { Callout } from 'nextra/components';
 
 # Netfox

--- a/content/integrations.mdx
+++ b/content/integrations.mdx
@@ -1,3 +1,8 @@
+---
+title: "Integrations — Prometheus & Grafana"
+description: "Expose Netfox on a Prometheus-compatible /metrics endpoint and chart your network — open ports, device state, throughput — in Grafana."
+---
+
 import { Callout } from 'nextra/components';
 
 # Integrations

--- a/content/keyboard-shortcuts.mdx
+++ b/content/keyboard-shortcuts.mdx
@@ -1,3 +1,8 @@
+---
+title: "Keyboard Shortcuts"
+description: "Every Netfox keyboard shortcut: switch tools, refresh, probe ports, open alert history, and toggle Demo and Advanced mode."
+---
+
 import { Callout } from 'nextra/components';
 
 # Keyboard Shortcuts

--- a/content/menu-bar.mdx
+++ b/content/menu-bar.mdx
@@ -1,3 +1,8 @@
+---
+title: "Menu Bar"
+description: "Netfox's menu bar popover keeps devices online, risk level, public IP and live traffic one click away — even with the main window closed."
+---
+
 import { Callout } from 'nextra/components';
 
 # Menu Bar

--- a/content/settings.mdx
+++ b/content/settings.mdx
@@ -1,3 +1,8 @@
+---
+title: "Settings"
+description: "Every Netfox preference explained: alerts, scheduled security probes, custom ports, privacy controls and the Prometheus metrics endpoint."
+---
+
 import { Callout } from 'nextra/components';
 
 # Settings

--- a/content/tools/devices.mdx
+++ b/content/tools/devices.mdx
@@ -1,3 +1,8 @@
+---
+title: "Device List & History"
+description: "Netfox lists every device on your LAN with a per-device timeline: identity, network details, history and the services each one exposes."
+---
+
 import { Callout } from 'nextra/components';
 
 # Devices

--- a/content/tools/optimization.mdx
+++ b/content/tools/optimization.mdx
@@ -1,3 +1,8 @@
+---
+title: "Optimization"
+description: "What's next for Netfox: Wi-Fi diagnostics, link diagnostics and a bandwidth monitor — a preview of the upcoming optimization tools."
+---
+
 import { Callout } from 'nextra/components';
 
 # Optimization

--- a/content/tools/overview.mdx
+++ b/content/tools/overview.mdx
@@ -1,3 +1,8 @@
+---
+title: "Overview Dashboard"
+description: "The Netfox Overview dashboard puts devices, risk posture, your public IP and the alert inbox on one screen — your whole network at a glance."
+---
+
 import { Callout } from 'nextra/components';
 
 # Overview

--- a/content/tools/security.mdx
+++ b/content/tools/security.mdx
@@ -1,3 +1,8 @@
+---
+title: "Network Security Scanner"
+description: "Netfox probes each device for risky open ports and explains every finding in plain English, with a colour-coded risk badge per device."
+---
+
 import { Callout } from 'nextra/components';
 
 # Security

--- a/content/tools/wifi.mdx
+++ b/content/tools/wifi.mdx
@@ -1,3 +1,8 @@
+---
+title: "Wi-Fi Scanner"
+description: "Scan every Wi-Fi network your Mac can see with Netfox: live signal strength, channel, band, security mode and a per-network signal chart."
+---
+
 import { Callout } from 'nextra/components';
 
 # Wi-Fi

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,9 @@
 # https://netfox.app/robots.txt
 #
 # Search engines are welcome.
+
+Sitemap: https://netfox.app/sitemap.xml
+
 User-agent: Googlebot
 Allow: /
 
@@ -65,10 +68,10 @@ Disallow: /
 User-agent: Meta-ExternalFetcher
 Disallow: /
 
+# Note: facebookexternalhit is intentionally NOT blocked — it's the
+# crawler that renders link previews on Facebook / Messenger / WhatsApp /
+# Instagram, so blocking it would kill rich previews when the site is shared.
 User-agent: FacebookBot
-Disallow: /
-
-User-agent: facebookexternalhit
 Disallow: /
 
 User-agent: Facebot


### PR DESCRIPTION
## What

Audit-driven SEO improvements for netfox.app. The site already had a solid baseline (good title/template, `metadataBase`, correctly-sized OG/Twitter images, per-page canonicals, a thoughtful AI-blocking robots.txt). This PR closes the high-impact gaps the audit surfaced.

## Changes (audit P0 + P1)

**Discoverability**
- **`app/sitemap.ts`** — there was no sitemap at all. Now emits an XML sitemap covering the homepage + every `/docs/*` page (15 URLs).
- **`robots.txt`** — added the `Sitemap:` directive; **unblocked `facebookexternalhit`** — it was grouped with the AI-training blocks, but it's the crawler that renders link previews on Facebook / Messenger / WhatsApp / Instagram, so blocking it was killing rich previews when the site is shared (it's actively being shared for launches). The real AI trainers (GPTBot, ClaudeBot, FacebookBot, Bytespider, …) stay blocked.

**On-page (biggest lever)**
- **Per-page `title` + `description` frontmatter on 12 content pages.** Verified pre-change: every docs page emitted the *same generic homepage description*, and titles were inconsistent (some generic, some specific). Now each page has a unique, keyword-targeted title and description.

**Rich results**
- **`components/StructuredData`** — site-wide JSON-LD: `SoftwareApplication` (free macOS app → eligible for Google app rich results), plus `Organization` and `WebSite`. Values sourced from `config` so they stay in sync.

**Mobile / technical**
- **`app/manifest.ts`** — web app manifest (PWA identity, `theme_color`). Next auto-injects `<link rel="manifest">`.
- **Layout** — removed `user-scalable=no` from the viewport (an accessibility/SEO ding that disables pinch-zoom); added `theme-color` meta and the SVG favicon link.

## Verification

Built and served a local production server; confirmed:
- `/sitemap.xml` → 15 URLs (home + all docs incl. nested `/docs/tools/*`)
- `/manifest.webmanifest` → valid, themed, with maskable icon
- `robots.txt` → `Sitemap:` present, `facebookexternalhit` allowed
- Per-page meta now unique (e.g. `/docs/tools/security` → "Network Security Scanner | Netfox" + its own description)
- `SoftwareApplication` JSON-LD present; `<meta name="viewport">` has no `user-scalable=no`; single H1 per docs page preserved

`yarn build`, `yarn typecheck`, `yarn lint` all green.

## Deferred (audit P2 — separate pass)
- Recompress OG/Twitter images (~808 KB → <300 KB)
- `next/image` for the hero/LCP image (currently Mantine `Image`)
- Optional: keyword in the homepage H1; `FAQPage`/`BreadcrumbList` schema (lower value since Google curtailed FAQ rich results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added web app manifest (icons, theme color, standalone display) for improved PWA installation.
  * Implemented Schema.org structured data to enhance rich search results.
  * Generated an automated sitemap from documentation content for better indexing.
  * Added Prometheus/Grafana integration documentation, including the `/metrics` endpoint and configuration guidance.
* **Chores**
  * Added SEO-friendly title/description frontmatter to multiple documentation pages.
  * Improved favicon and `theme-color` setup, and updated `robots.txt`/sitemap directives for crawler compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->