### PR TITLE
feat(home): direct .dmg download + macOS download details

### DIFF
--- a/app/download/route.ts
+++ b/app/download/route.ts
@@ -1,0 +1,79 @@
+import config from '@/config';
+
+// Always run per-request so the link tracks the latest release (the GitHub API
+// response itself is cached for a few minutes via `revalidate`).
+export const dynamic = 'force-dynamic';
+
+const FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * `/download` — redirects straight to the latest macOS `.dmg` instead of the
+ * GitHub Releases page. Resolves the asset from the Releases API at request
+ * time, so the public URL carries no version and never goes stale.
+ *
+ * The releases repo also hosts the website template's own `vX` releases, so we
+ * skip anything whose name doesn't start with the app prefix and pick the first
+ * (newest) release that actually carries a `.dmg`. Any failure falls back to
+ * the Releases page so the button is never a dead end.
+ */
+export async function GET() {
+  const fallback = config.app.downloadUrl; // GitHub Releases page
+
+  const redirect = (location: string) =>
+    new Response(null, { status: 302, headers: { Location: location, 'Cache-Control': 'no-store' } });
+
+  try {
+    const url = `${config.gitHub.releasesUrl}?per_page=${config.releaseNotes.maxReleases}`;
+    const baseHeaders: Record<string, string> = {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': config.gitHub.repo.split('/')[1] || 'website',
+    };
+    const opts = {
+      next: { revalidate: 600 },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    } as const;
+
+    let response: Response;
+    if (process.env.GITHUB_TOKEN) {
+      response = await fetch(url, {
+        ...opts,
+        headers: { ...baseHeaders, Authorization: `Bearer ${process.env.GITHUB_TOKEN}` },
+      });
+      const rateRemaining = response.headers.get('x-ratelimit-remaining');
+      if (response.status === 401 || (response.status === 403 && rateRemaining !== '0')) {
+        await response.text(); // release the connection before retrying
+        response = await fetch(url, {
+          ...opts,
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+          headers: baseHeaders,
+        });
+      }
+    } else {
+      response = await fetch(url, { ...opts, headers: baseHeaders });
+    }
+
+    if (!response.ok) return redirect(fallback);
+
+    const releases = await response.json();
+    const prefix = config.releaseNotes.appReleaseNamePrefix;
+    let dmgUrl: string | undefined;
+    if (Array.isArray(releases)) {
+      for (const r of releases) {
+        if (r?.draft || r?.prerelease) continue;
+        // Skip the website template's own releases that share this repo.
+        if (typeof r?.name === 'string' && !r.name.startsWith(prefix)) continue;
+        const dmg = (r?.assets ?? []).find(
+          (a: any) => typeof a?.name === 'string' && a.name.toLowerCase().endsWith('.dmg')
+        );
+        if (dmg?.browser_download_url) {
+          dmgUrl = dmg.browser_download_url;
+          break;
+        }
+      }
+    }
+
+    return redirect(dmgUrl ?? fallback);
+  } catch {
+    return redirect(fallback);
+  }
+}

--- a/components/Welcome/Welcome.tsx
+++ b/components/Welcome/Welcome.tsx
@@ -29,6 +29,7 @@ import {
   Stack,
   Text,
   Title,
+  Anchor,
 } from '@mantine/core';
 import config from '@/config';
 import { FAQ } from '../FAQ/FAQ';
@@ -309,7 +310,7 @@ export function Welcome() {
 
             <Group justify="center" mt="md">
               <Button
-                href={config.app.downloadUrl}
+                href="/download"
                 component="a"
                 leftSection={<IconDownload size={20} />}
                 size="xl"
@@ -330,6 +331,16 @@ export function Welcome() {
                 See what it does
               </Button>
             </Group>
+
+            <Stack gap={4} align="center" mt={8}>
+              <Text c="dimmed" ta="center" size="sm">
+                Free &middot; v{config.app.version} &middot; macOS 15+ &middot; Universal (Apple Silicon + Intel) &middot;
+                Signed &amp; notarized
+              </Text>
+              <Anchor href="/docs/release-notes" c="dimmed" size="sm">
+                Release notes
+              </Anchor>
+            </Stack>
 
             {/* ─── Product Hunt launch badge ─── */}
             {/*
@@ -537,7 +548,7 @@ export function Welcome() {
               </Text>
 
               <Button
-                href={config.app.downloadUrl}
+                href="/download"
                 component="a"
                 leftSection={<IconDownload size={20} />}
                 size="xl"


### PR DESCRIPTION
## What
- **New `/download` route** (`app/download/route.ts`): resolves the latest macOS `.dmg` from the Releases API and **302-redirects** straight to it. No version in the public URL, always the latest. Skips the website template's own `vX` releases (shared repo) and falls back to the Releases page on any error. Uses `GITHUB_TOKEN` when set (same pattern as `/api/github-releases`).
- **Hero Download button → `/download`** (both CTAs), one click to the binary instead of the GitHub Releases page.
- **Download details line** under the hero CTA: version (from `config.app.version`), macOS 15+, Universal (Apple Silicon + Intel), signed & notarized — plus a **Release notes** link (`/docs/release-notes`).

## Test on the preview
- Homepage hero: the details line shows under the buttons.
- Click **Download for macOS** → should download `Netfox-X.Y.Z.dmg` directly (not the GitHub page).
- `/download` → 302 to the latest `.dmg`.

typecheck + lint green. Homepage component → ships as its own PR (not bundled by release.sh). Cross-port of gfazioli/findergit-website#27.