### PR TITLE
docs(faq): menu bar icon hidden behind the notch

### DIFF
--- a/components/FAQ/FAQ.tsx
+++ b/components/FAQ/FAQ.tsx
@@ -69,6 +69,12 @@ const faqItems = [
       'Netfox checks for new releases in the background (every 24 hours by default) and prompts you when one is available. Builds are signed with Apple Developer ID and notarized by Apple, so the update installs without a Gatekeeper detour. You can disable the auto-check or trigger a manual one from Settings → Updates.',
   },
   {
+    value: 'menubar-icon-hidden',
+    question: "I can't see the Netfox icon in the menu bar",
+    answer:
+      "On Macs with a notch, a busy menu bar can push status icons behind the notch, where macOS simply stops showing them — Netfox included. The icon isn't gone, it's just hidden. To bring it back: hold Command and drag the menu bar icons to reorder them so Netfox sits clear of the notch; remove a few icons you don't use from System Settings → Control Center; or use a menu bar manager (such as Ice or Bartender) that tucks overflow icons into an expandable section. Picking the monochrome menu bar icon in Settings → General also helps, since it's narrower than the full-color fox.",
+  },
+  {
     value: 'bug',
     question: 'I found a bug. How do I report it?',
     answer: 'bug-report',


### PR DESCRIPTION
## Summary

Adds an FAQ entry for a question notch-MacBook users will hit: the Netfox menu bar icon not showing up.

On Macs with a notch, a busy menu bar pushes status icons behind the notch where macOS stops rendering them — Netfox included. The entry explains the icon isn't gone and lists the fixes:
- ⌘-drag to reorder the menu bar icons clear of the notch
- trim unused icons from System Settings → Control Center
- use a menu bar manager (Ice / Bartender) for overflow
- pick the narrower monochrome menu bar icon in Settings → General

Plain-text entry, same shape as the existing `faqItems` (no markdown/JSX). Placed between the "updates" and "bug" entries. Ice/Bartender are end-user tools (not infrastructure), so naming them is within the content guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FAQ entry with troubleshooting guidance for users unable to see the Netfox icon in the menu bar on notched Macs, including steps for menu bar customization and recommendations for menu bar management tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->