### PR TITLE
docs(roadmap): frame readability as the cross-cutting through-line

### DIFF
--- a/content/roadmap.mdx
+++ b/content/roadmap.mdx
@@ -10,6 +10,8 @@ Netfox grows one module at a time. Each release ships a focused piece of the big
 
 **The order is the promise, not the version number.** Netfox is built by one person, and what ships next is sometimes whatever the moment calls for — so rather than pin each module to a "v0.X" that keeps moving, the list below commits to *sequence*. Modules land in this order; the version they land in is whatever it is when they're ready.
 
+**Readability is the through-line.** Whatever the next module is, every release is also measured by one question: *does it make more of your network legible in plain English?* Turning a cryptic `ESP-8A2F` into "Espressif · web server on :80" is the heart of Netfox — so device identity, naming, and "what is this thing, really?" keep getting sharper release over release, alongside the modules below.
+
 ## Where we are today
 
 Netfox **0.7** is live. The current build covers:


### PR DESCRIPTION
Keeps the public roadmap in sync with the app repo's new **readability pillar** (Netfox/ROADMAP.md + DIRECTION.md).

The module sequence is **unchanged** — Wi-Fi diagnostics is still next. This only adds one framing paragraph: every release is also measured by how much more of the network it makes legible in plain English ("machine speak → humanese").

Disjoint from the open homepage-positioning PR #28 (touches only `content/roadmap.mdx`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product roadmap to highlight upcoming focus on improving readability and user-friendliness of device naming and identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->