### PR TITLE
docs: document the localized app experience (EN/IT/FR/DE/ES)

### DIFF
--- a/components/FAQ/FAQ.tsx
+++ b/components/FAQ/FAQ.tsx
@@ -21,6 +21,12 @@ const faqItems = [
       'macOS 15 (Sequoia) or later. Netfox is built with SwiftUI and uses APIs available from macOS 15+.',
   },
   {
+    value: 'languages',
+    question: 'Which languages does Netfox speak?',
+    answer:
+      "English, Italian, French, German, and Spanish. Netfox follows your Mac's system language automatically — there is no in-app switcher. To use a different language, reorder your preferred languages in System Settings → General → Language & Region. Everything arrives localized: the five tools, Settings, the menu bar popover, even the macOS permission prompts and the post-update What's New panel.",
+  },
+  {
     value: 'how-detects',
     question: 'How does Netfox find devices?',
     answer:

--- a/components/StructuredData/StructuredData.tsx
+++ b/components/StructuredData/StructuredData.tsx
@@ -17,6 +17,7 @@ const structuredData = {
       name: 'Netfox',
       applicationCategory: 'UtilitiesApplication',
       operatingSystem: `macOS ${config.app.minMacOS} or later`,
+      inLanguage: ['en', 'it', 'fr', 'de', 'es'],
       description: config.metadata.description,
       url: BASE,
       downloadUrl: config.app.downloadUrl,

--- a/components/Welcome/Welcome.test.tsx
+++ b/components/Welcome/Welcome.test.tsx
@@ -4,6 +4,6 @@ import { Welcome } from './Welcome';
 describe('Welcome component', () => {
   it('renders the hero title', () => {
     render(<Welcome />);
-    expect(screen.getByText(/know who's on your network/i)).toBeInTheDocument();
+    expect(screen.getByText(/^your network,/i)).toBeInTheDocument();
   });
 });

--- a/components/Welcome/Welcome.tsx
+++ b/components/Welcome/Welcome.tsx
@@ -184,7 +184,8 @@ const features = [
   {
     icon: IconDeviceDesktop,
     title: 'Native macOS',
-    description: 'Built in SwiftUI for macOS 15+. Follows system appearance. Universal binary.',
+    description:
+      'Built in SwiftUI for macOS 15+. Follows your system appearance and language — localized in English, Italian, French, German, and Spanish. Universal binary.',
     accent: 'var(--mantine-color-grape-5)',
     href: '/docs/getting-started',
   },

--- a/content/getting-started.mdx
+++ b/content/getting-started.mdx
@@ -126,6 +126,12 @@ Netfox uses a built-in auto-update framework. By default it checks once a day in
 
 After an update installs and you reopen Netfox, a **What's New** panel sums up what changed in that release. It appears for every update — including small patch releases — so you never miss a fix or improvement, and you can revisit it any time from **Help → What's New**.
 
+## Language
+
+Netfox ships in **English, Italian, French, German, and Spanish** and follows your Mac's system language automatically — there is no in-app language switcher. To run Netfox in a different language, reorder your preferred languages in **System Settings → General → Language & Region** (macOS applies the first language an app supports).
+
+The whole experience arrives localized: the five tools, Settings, the menu bar popover and notch HUD, the macOS permission prompts, and the post-update What's New panel. Counts and labels inflect correctly in every language.
+
 ## Tips
 
 - <Kbd>⌘</Kbd> <Kbd>R</Kbd> or the toolbar refresh button forces every discovery provider to emit immediately

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -42,6 +42,7 @@ Each tool reads from the same shared device store, so a finding in one shows up 
 - **Prometheus metrics endpoint** — an opt-in `/metrics` endpoint exposes open ports, device presence, last-seen times, throughput, and alert counts in the [Prometheus](https://prometheus.io) format, so homelab users can scrape it and chart it in Grafana. Off by default, localhost-bound, optional token — see [Integrations](/docs/integrations)
 - **Tabbed Settings** — General · Alerts · Security · Privacy · Integrations · Advanced · Updates · About
 - **No account, no cloud, no telemetry** — every observation lives on your Mac
+- **Speaks your language** — fully localized into English, Italian, French, German, and Spanish; Netfox follows your Mac's system language automatically, nothing to configure
 - **Universal binary** — runs on Apple Silicon and Intel Macs; macOS picks the right slice at launch
 - **Auto-updates** — built in, signed; the app checks for new versions automatically and prompts you when one is available
 


### PR DESCRIPTION
## What

Documents Netfox's localized experience — **English, Italian, French, German, and Spanish**, shipped in the app since v0.11.0 — across the website, mirroring the pattern already live on findergit-website:

- **Getting Started** — new `## Language` section: supported languages, how macOS picks one (System Settings → General → Language & Region), and what arrives localized (five tools, Settings, menu bar popover + notch HUD, permission prompts, What's New panel)
- **Docs index** — new *Speaks your language* bullet in the "What it does" list
- **FAQ** — new entry *"Which languages does Netfox speak?"*
- **Homepage** — the *Native macOS* card now mentions the five languages (kept inside the existing card to preserve the 3×3 feature grid)
- **JSON-LD** — `inLanguage: [en, it, fr, de, es]` on the `SoftwareApplication` node

Copy is limited to the languages the app actually ships today; new languages will be added to these pages when they ship in the app.

## Also

- Fixes the only Jest suite, which was failing on `main`: the hero-title assertion still targeted the pre-positioning headline ("know who's on your network"). It now asserts the static half of the current headline ("Your network, …") — the animated half renders as per-character spans and is not matchable as text.

## Verification

- `yarn test` green end-to-end (typegen, oxfmt check, oxlint + stylelint, typecheck, jest)
- Language claims cross-checked against the app's string catalogs on `main` (`Localizable.xcstrings` / `InfoPlist.xcstrings`: en, it, fr, de, es)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
