### PR TITLE
feat(i18n): Portuguese & Dutch language docs + flag emoji

### DIFF
--- a/components/FAQ/FAQ.tsx
+++ b/components/FAQ/FAQ.tsx
@@ -24,7 +24,7 @@ const faqItems = [
     value: 'languages',
     question: 'Which languages does Netfox speak?',
     answer:
-      "English, Italian, French, German, and Spanish. Netfox follows your Mac's system language automatically — there is no in-app switcher. To use a different language, reorder your preferred languages in System Settings → General → Language & Region. Everything arrives localized: the five tools, Settings, the menu bar popover, even the macOS permission prompts and the post-update What's New panel.",
+      "🇬🇧 English, 🇮🇹 Italian, 🇫🇷 French, 🇩🇪 German, 🇪🇸 Spanish, 🇵🇹 Portuguese, and 🇳🇱 Dutch — seven in all. Netfox follows your Mac's system language automatically; there is no in-app switcher. To use a different language, reorder your preferred languages in System Settings → General → Language & Region. Everything arrives localized: the tools, Settings, the menu bar popover and notch HUD, even the macOS permission prompts and the post-update What's New panel.",
   },
   {
     value: 'how-detects',

--- a/components/StructuredData/StructuredData.tsx
+++ b/components/StructuredData/StructuredData.tsx
@@ -17,7 +17,7 @@ const structuredData = {
       name: 'Netfox',
       applicationCategory: 'UtilitiesApplication',
       operatingSystem: `macOS ${config.app.minMacOS} or later`,
-      inLanguage: ['en', 'it', 'fr', 'de', 'es'],
+      inLanguage: ['en', 'it', 'fr', 'de', 'es', 'pt', 'nl'],
       description: config.metadata.description,
       url: BASE,
       downloadUrl: config.app.downloadUrl,

--- a/components/Welcome/Welcome.tsx
+++ b/components/Welcome/Welcome.tsx
@@ -185,7 +185,7 @@ const features = [
     icon: IconDeviceDesktop,
     title: 'Native macOS',
     description:
-      'Built in SwiftUI for macOS 15+. Follows your system appearance and language — localized in English, Italian, French, German, and Spanish. Universal binary.',
+      'Built in SwiftUI for macOS 15+. Follows your system appearance and language — localized in 7 languages 🇬🇧 🇮🇹 🇫🇷 🇩🇪 🇪🇸 🇵🇹 🇳🇱. Universal binary.',
     accent: 'var(--mantine-color-grape-5)',
     href: '/docs/getting-started',
   },

--- a/content/getting-started.mdx
+++ b/content/getting-started.mdx
@@ -128,7 +128,11 @@ After an update installs and you reopen Netfox, a **What's New** panel sums up w
 
 ## Language
 
-Netfox ships in **English, Italian, French, German, and Spanish** and follows your Mac's system language automatically — there is no in-app language switcher. To run Netfox in a different language, reorder your preferred languages in **System Settings → General → Language & Region** (macOS applies the first language an app supports).
+Netfox ships in **seven languages** and follows your Mac's system language automatically — there is no in-app language switcher:
+
+🇬🇧 English · 🇮🇹 Italian · 🇫🇷 French · 🇩🇪 German · 🇪🇸 Spanish · 🇵🇹 Portuguese · 🇳🇱 Dutch
+
+To run Netfox in a different language, reorder your preferred languages in **System Settings → General → Language & Region** (macOS applies the first language an app supports).
 
 The whole experience arrives localized: the five tools, Settings, the menu bar popover and notch HUD, the macOS permission prompts, and the post-update What's New panel. Counts and labels inflect correctly in every language.
 

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -42,7 +42,7 @@ Each tool reads from the same shared device store, so a finding in one shows up 
 - **Prometheus metrics endpoint** — an opt-in `/metrics` endpoint exposes open ports, device presence, last-seen times, throughput, and alert counts in the [Prometheus](https://prometheus.io) format, so homelab users can scrape it and chart it in Grafana. Off by default, localhost-bound, optional token — see [Integrations](/docs/integrations)
 - **Tabbed Settings** — General · Alerts · Security · Privacy · Integrations · Advanced · Updates · About
 - **No account, no cloud, no telemetry** — every observation lives on your Mac
-- **Speaks your language** — fully localized into English, Italian, French, German, and Spanish; Netfox follows your Mac's system language automatically, nothing to configure
+- **Speaks your language** 🇬🇧 🇮🇹 🇫🇷 🇩🇪 🇪🇸 🇵🇹 🇳🇱 — fully localized into English, Italian, French, German, Spanish, Portuguese, and Dutch; Netfox follows your Mac's system language automatically, nothing to configure
 - **Universal binary** — runs on Apple Silicon and Intel Macs; macOS picks the right slice at launch
 - **Auto-updates** — built in, signed; the app checks for new versions automatically and prompts you when one is available
 


### PR DESCRIPTION
## What

Netfox 0.11.2 adds **Portuguese (pt-PT)** and **Dutch (nl)**, taking the app to **seven** UI languages. This updates every language-facing surface on the site to say so, and gives localization more visual prominence with flag emoji.

| Surface | Change |
|---|---|
| `content/getting-started.mdx` — Language | "seven languages" + a dedicated flag row 🇬🇧 🇮🇹 🇫🇷 🇩🇪 🇪🇸 🇵🇹 🇳🇱 |
| `content/index.mdx` — *Speaks your language* | flags + PT/NL in the copy |
| `components/Welcome` — *Native macOS* card | "7 languages" + flags |
| `components/FAQ` — *Which languages…* | PT/NL + flags, adds the notch HUD |
| `components/StructuredData` — JSON-LD | `inLanguage` gains `pt`, `nl` |

## Why

Pairs with the app localization work (Netfox PR #162, PT/NL to IT parity). The site previously listed only the five original languages.

## Verification

`yarn test` green — typegen, oxfmt `--check`, oxlint, stylelint, typecheck, jest (1/1).

## Note

🇵🇹 is **European** Portuguese, matching the app translation. If pt-BR is ever added, swap the flag to 🇧🇷.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated language-related copy across the site to reflect support for seven languages instead of five.
  * Added Portuguese and Dutch to the listed supported languages.
  * Clarified language support in the FAQ, getting-started content, and homepage messaging.
* **Bug Fixes**
  * Kept the app’s language guidance aligned with current supported locales and system language behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->