### PR TITLE
feat(docs): color the docs sidebar icons

### DIFF
--- a/content/_meta.tsx
+++ b/content/_meta.tsx
@@ -13,18 +13,22 @@ import {
 } from '@tabler/icons-react';
 import { nav } from '@/lib/nav-helper';
 
+// Colored to echo the app's palette (the Tools submenu already maps its
+// entries to the per-tool gradient hues). Utility pages — Settings,
+// Keyboard Shortcuts — stay uncolored so the feature pages read first,
+// mirroring the FinderGit docs sidebar.
 export default {
-  index: nav(IconBook2, 'Introduction'),
+  index: nav(IconBook2, 'Introduction', 'var(--mantine-color-blue-5)'),
   '---': { type: 'separator' },
-  'getting-started': nav(IconRocket, 'Getting Started'),
-  tools: nav(IconTool, 'Tools'),
-  'menu-bar': nav(IconLayoutNavbar, 'Menu Bar'),
-  notch: nav(IconLayoutNavbarExpand, 'Notch HUD'),
+  'getting-started': nav(IconRocket, 'Getting Started', 'var(--mantine-color-orange-5)'),
+  tools: nav(IconTool, 'Tools', 'var(--mantine-color-grape-5)'),
+  'menu-bar': nav(IconLayoutNavbar, 'Menu Bar', 'var(--mantine-color-cyan-5)'),
+  notch: nav(IconLayoutNavbarExpand, 'Notch HUD', 'var(--mantine-color-violet-5)'),
   settings: nav(IconSettings, 'Settings'),
-  integrations: nav(IconChartLine, 'Integrations'),
+  integrations: nav(IconChartLine, 'Integrations', 'var(--mantine-color-teal-5)'),
   'keyboard-shortcuts': nav(IconKeyboard, 'Keyboard Shortcuts'),
   '----': { type: 'separator' },
-  faq: nav(IconHelpCircle, 'FAQ'),
-  'release-notes': nav(IconHistory, 'Release Notes'),
-  roadmap: nav(IconRoute, 'Roadmap'),
+  faq: nav(IconHelpCircle, 'FAQ', 'var(--mantine-color-blue-5)'),
+  'release-notes': nav(IconHistory, 'Release Notes', 'var(--mantine-color-green-5)'),
+  roadmap: nav(IconRoute, 'Roadmap', 'var(--mantine-color-pink-5)'),
 };


### PR DESCRIPTION
The docs sidebar showed grey monochrome icons at the top level, while the Tools submenu already colors its entries to the app's per-tool palette. Pass per-entry Mantine color vars to the existing nav() helper so the root icons match. Utility pages (Settings, Keyboard Shortcuts) stay grey to keep feature pages reading first — same pattern as the FinderGit docs sidebar. Data-only; `yarn test` green (typecheck/lint/jest). Preview with yarn dev before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the documentation navigation with color accents for several sections, making the menu more visually distinct and easier to scan.
  * Added colored styling to sections like Introduction, Getting Started, Tools, Menu Bar, Notch HUD, Integrations, FAQ, Release Notes, and Roadmap.

* **Style**
  * Kept Settings and Keyboard Shortcuts in the default uncolored style for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->