### PR TITLE
feat(seo): attribute Twitter/X cards to @gfazioli

### DIFF
--- a/config/index.ts
+++ b/config/index.ts
@@ -39,6 +39,8 @@ export default {
     },
     twitter: {
       card: 'summary_large_image',
+      site: '@gfazioli',
+      creator: '@gfazioli',
     },
     alternates: {
       canonical: './',


### PR DESCRIPTION
## What

Adds `twitter.site` and `twitter.creator` (`@gfazioli`) to the root metadata in `config/index.ts`, so shared Netfox links render a "from @gfazioli" byline on X and the account accrues the card's engagement.

## Why

The site declared only `twitter: { card: 'summary_large_image' }` — cards carried no account attribution. `@gfazioli` is the handle already linked in the footer (`components/MantineFooter/MantineFooter.tsx`).

## Verification

- `tsc --noEmit` clean.
- Live check after merge: confirm the homepage emits `twitter:site`/`twitter:creator` = `@gfazioli`.

Backport of the same fix just shipped on findergit-website (twin Mantine/Next/Nextra template). A parallel SEO check also confirmed the `/docs/*` canonical is already correct here — Next.js resolves the inherited relative `./` against the current route — so no other change is warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
