### PR TITLE
docs(roadmap): bring the public roadmap up to 0.15.0

### DIFF
--- a/content/roadmap.mdx
+++ b/content/roadmap.mdx
@@ -14,7 +14,7 @@ Netfox grows one module at a time. Each release ships a focused piece of the big
 
 ## Where we are today
 
-Netfox **0.13** is live. The current build covers:
+Netfox **0.15** is live. The current build covers:
 
 - **Discovery & history** — every device you've ever had on the network is remembered with a timeline, discovered across multiple protocols. The timeline now records **port-state changes** too, so you can see when a service appeared or went away.
 - **Alerts** — new devices, returning devices, risky arrivals, port changes, new services. Inbox + history + per-device mute, and the port-opened alert can optionally include your own Mac.
@@ -26,6 +26,9 @@ Netfox **0.13** is live. The current build covers:
 - **Your language** — the interface follows macOS across English, Italian, French, German, Spanish, Portuguese and Dutch.
 - **Notch quick view** — a Dynamic-Island-style overlay under the MacBook notch with your network at a glance.
 - **Monitoring integration** — an opt-in, read-only metrics endpoint your own Prometheus can scrape, off by default and refusing to serve the network unauthenticated.
+- **Device identity** — devices are identified by the model they announce about themselves rather than guessed from their name, and the manufacturer comes from the full public hardware registry. A randomized address says "Private address" rather than leaving the field blank.
+- **Network settings** — what your network hands out to everything on it: the network name, address range, router, name servers, domain and lease, on the Overview. Each device shows the roles it plays — gateway, name resolver, address server.
+- **Link quality** — the round trip to each device, how steady it is, how often it doesn't answer, and a chart of the day. Not the device's own signal, which only the device can measure: the path between your Mac and it.
 - **Menu bar** — a quick-glance popover with your network's status: Devices and Risk as ring gauges, public IP and alerts alongside, plus a live chart of your Mac's traffic, and cards that deep-link straight into the app. Two icon styles: an adaptive monochrome glyph or the colour fox.
 
 ## What's next


### PR DESCRIPTION
The page still said "Netfox **0.13** is live" — two releases behind, and missing device identity, the network-settings panel and link quality from the "current build covers" list.

This is the drift the project notes warn about: the same page once sat at 0.7 for five minors. Fixing it in the release motion rather than as a someday task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap to reflect Netfox 0.15.
  * Expanded details for Device identity, Network settings, and Link quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->