### PR TITLE
docs: correct the macOS floor everywhere, and two overstated claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,9 @@ User-facing pages (`content/*.mdx`, the homepage, release notes hosted at `publi
 - ❌ "Groq", "Llama", "OpenAI", "Anthropic" — say "the AI" or "the AI provider"
 - ❌ "Vercel proxy", "Next.js API route", "Cloudflare Worker" — say "Netfox handles the request on your behalf"
 - ❌ "Sparkle", "AppKit's NSEvent monitor", framework names — say "the auto-update framework" / "macOS keyboard handling"
-- ✅ User-relevant facts ARE allowed: "free", "no account required", "data never leaves your Mac", "macOS 15+ required"
+- ✅ User-relevant facts ARE allowed: "free", "no account required", "data never leaves your Mac", "macOS 15.6+ required"
+
+**The macOS floor is 15.6, not 15.** Take it from `MACOSX_DEPLOYMENT_TARGET` in the app's pbxproj (it also drives `sparkle:minimumSystemVersion` in the appcast) — never from FinderGit, whose floor is different. Six places on this site said "macOS 15+" / "macOS 15 (Sequoia)" until 2026-08-05, which told anyone on 15.0–15.5 the app would run when Sparkle would never offer it and the binary would not launch. When the deployment target moves, grep the whole site for the old value rather than fixing the page you happen to be on.
 
 Reasoning: end users care about what the feature does for them, not which vendor or library powers it. Naming the stack also paints us into a corner if we ever swap it — would force rewriting every page.
 

--- a/components/FAQ/FAQ.tsx
+++ b/components/FAQ/FAQ.tsx
@@ -18,7 +18,7 @@ const faqItems = [
     value: 'macos',
     question: 'What macOS version do I need?',
     answer:
-      'macOS 15.6 (Sequoia) or later. Netfox is built with SwiftUI and uses APIs available from macOS 15.6 onward.',
+      'macOS 15.6 (Sequoia) or later. Netfox is built natively for macOS and uses system APIs available from 15.6 onward.',
   },
   {
     value: 'languages',

--- a/components/FAQ/FAQ.tsx
+++ b/components/FAQ/FAQ.tsx
@@ -18,7 +18,7 @@ const faqItems = [
     value: 'macos',
     question: 'What macOS version do I need?',
     answer:
-      'macOS 15 (Sequoia) or later. Netfox is built with SwiftUI and uses APIs available from macOS 15+.',
+      'macOS 15.6 (Sequoia) or later. Netfox is built with SwiftUI and uses APIs available from macOS 15.6 onward.',
   },
   {
     value: 'languages',

--- a/components/Welcome/Welcome.tsx
+++ b/components/Welcome/Welcome.tsx
@@ -186,7 +186,7 @@ const features = [
     icon: IconDeviceDesktop,
     title: 'Native macOS',
     description:
-      'Built in SwiftUI for macOS 15+. Follows your system appearance and language — localized in 7 languages 🇬🇧 🇮🇹 🇫🇷 🇩🇪 🇪🇸 🇵🇹 🇳🇱. Universal binary.',
+      'Built in SwiftUI for macOS 15.6+. Follows your system appearance and language — localized in 7 languages 🇬🇧 🇮🇹 🇫🇷 🇩🇪 🇪🇸 🇵🇹 🇳🇱. Universal binary.',
     accent: 'var(--mantine-color-grape-5)',
     href: '/docs/getting-started',
   },
@@ -297,7 +297,7 @@ export function Welcome() {
                 boxShadow: '0 8px 22px -8px rgba(247, 103, 7, 0.45)',
               }}
             >
-              Free for macOS 15+
+              Free for macOS 15.6+
             </Badge>
 
             <Image
@@ -371,7 +371,7 @@ export function Welcome() {
 
             <Stack gap={4} align="center" mt={8}>
               <Text c="dimmed" ta="center" size="sm">
-                Free &middot; v{config.app.version} &middot; macOS 15+ &middot; Universal (Apple
+                Free &middot; v{config.app.version} &middot; macOS 15.6+ &middot; Universal (Apple
                 Silicon + Intel) &middot; Signed &amp; notarized
               </Text>
               <Anchor href="/docs/release-notes" c="dimmed" size="sm">
@@ -644,7 +644,7 @@ export function Welcome() {
                 Download for macOS
               </Button>
               <Text c="white" size="sm">
-                Free &middot; macOS 15 Sequoia or later
+                Free &middot; macOS 15.6 Sequoia or later
               </Text>
             </Stack>
           </Container>

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -37,7 +37,7 @@ Each tool reads from the same shared device store, so a finding in one shows up 
 - **Tagging** — right-click any device to give it a custom name and icon. Useful for the cryptic vendor-name rows ("Espressif Inc.") that mean nothing without context
 - **Probe on demand** — right-click → *Probe This Device* (refresh online state) or *Probe Ports* (re-run the security check) without waiting for the next pass
 - **Demo Mode** (<Kbd>⌘</Kbd> <Kbd>⇧</Kbd> <Kbd>D</Kbd>) — one-keystroke privacy mask for screenshots and demos: device names collapse to `Computer #1`, MACs lose their last three octets, IPv6 loses everything past the first hextet, Wi-Fi SSIDs become `Network #N`. Render-only — the underlying store is untouched
-- **Local Services** — what your own Mac is listening on, asked of the system instead of probed over the network. That distinction matters: a dev server bound to loopback genuinely refuses connections from anywhere else, so a network check calls it closed — accurately, and uselessly. Grouped into *only on this Mac* and *reachable from the network*, with `/etc/hosts` names beside the port where you have them, so `3000` reads as `shop.local:3000`
+- **Local Services** — what your own Mac is listening on, asked of the system instead of probed over the network. That distinction matters: a dev server bound to loopback genuinely refuses connections from anywhere else, so a network check calls it closed — accurately, and uselessly. Grouped into *only on this Mac* and *reachable from the network*, each row naming the process behind the port — and where your `/etc/hosts` gives the address a name, `3000` reads as `shop.local:3000`
 - **This Mac, pinned** — the Mac running Netfox is always at the top of the Devices list, with its current Wi-Fi/Ethernet badge
 - **Advanced Mode** (<Kbd>⌘</Kbd> <Kbd>⇧</Kbd> <Kbd>M</Kbd>) — opt-in denser UI: MAC in the sidebar, Engine ID + absolute timestamps in the detail panel
 - **Prometheus metrics endpoint** — an opt-in `/metrics` endpoint exposes open ports, device presence, last-seen times, throughput, and alert counts in the [Prometheus](https://prometheus.io) format, so homelab users can scrape it and chart it in Grafana. Off by default, localhost-bound, optional token — see [Integrations](/docs/integrations)
@@ -49,7 +49,7 @@ Each tool reads from the same shared device store, so a finding in one shows up 
 
 ## Requirements
 
-- macOS 15 (Sequoia) or later
+- macOS 15.6 (Sequoia) or later
 - A local network — Wi-Fi, Ethernet, or anything macOS reports as an interface with a subnet
 - For the Wi-Fi tool, macOS requires Location permission to expose SSID details — Netfox asks once the first time you open the tool
 

--- a/content/roadmap.mdx
+++ b/content/roadmap.mdx
@@ -14,7 +14,7 @@ Netfox grows one module at a time. Each release ships a focused piece of the big
 
 ## Where we are today
 
-Netfox **0.16** is live. The current build covers:
+Netfox **0.16.5** is live. The current build covers:
 
 - **Discovery & history** — every device you've ever had on the network is remembered with a timeline, discovered across multiple protocols. The timeline now records **port-state changes** too, so you can see when a service appeared or went away.
 - **Alerts** — new devices, returning devices, risky arrivals, port changes, new services. Inbox + history + per-device mute, and the port-opened alert can optionally include your own Mac.
@@ -29,7 +29,7 @@ Netfox **0.16** is live. The current build covers:
 - **Device identity** — devices are identified by the model they announce about themselves rather than guessed from their name, and the manufacturer comes from the full public hardware registry. A randomized address says "Private address" rather than leaving the field blank.
 - **Network settings** — what your network hands out to everything on it: the network name, address range, router, name servers, domain and lease, on the Overview. Each device shows the roles it plays — gateway, name resolver, address server.
 - **Link quality** — the round trip to each device, how steady it is, how often it doesn't answer, and a chart of the day. Not the device's own signal, which only the device can measure: the path between your Mac and it.
-- **Local services** — what's listening on your own Mac, including the loopback-only ports a network check structurally cannot see, named by your hosts file so a forgotten dev server reads as the project it belongs to rather than as a number.
+- **Local services** — what's listening on your own Mac, including the loopback-only ports a network check structurally cannot see. Each row names the process behind it and how far it reaches, so a forgotten dev server on localhost is something you can find; where your hosts file gives the loopback address a name, that name is shown too.
 - **Menu bar** — a quick-glance popover with your network's status: Devices and Risk as ring gauges, public IP and alerts alongside, plus a live chart of your Mac's traffic, and cards that deep-link straight into the app. Two icon styles: an adaptive monochrome glyph or the colour fox.
 
 ## What's next

--- a/content/tools/devices.mdx
+++ b/content/tools/devices.mdx
@@ -204,9 +204,11 @@ Each row is the port, the process holding it, and its process ID. An (i) beside 
 
 ### Names instead of numbers
 
-`3000` tells you nothing. `shop.local:3000` tells you which project it is.
+`3000` tells you nothing. `shop.local:3000` gives you somewhere to start.
 
-If a listener's address has names pointing at it in your Mac's own hosts file, Netfox shows them next to the port. This is where a list of numbers turns into a list of *things* — the local sites, staging environments and side projects you set up months ago and forgot were still running.
+If a listener's address has names pointing at it in your Mac's own hosts file, Netfox shows them next to the port — the local sites, staging environments and side projects you set up months ago and forgot were still running.
+
+One thing to read correctly: a hosts entry points at an **address**, not at a port. A single name on `127.0.0.1` therefore applies to *every* loopback listener, and appears on every one of those rows — accurately, since the name does reach them all, but without telling them apart. The name is a lead, not a label: with several aliases it narrows things down, with exactly one it mostly reminds you the file exists.
 
 <Callout type="info">
 Nothing here needs a password, a permission prompt or a helper. Netfox reads what the system already knows about your own machine. Your own listeners come back complete; ones belonging to other user accounts or to the system may be partial, which is the cost of not asking for privileges. The whole tab is masked in [Demo Mode](/docs/settings#privacy) — a list of running processes is a software inventory, so process names, IDs and hosts-file names are all hidden before you share a screenshot.

--- a/content/tools/devices.mdx
+++ b/content/tools/devices.mdx
@@ -208,7 +208,9 @@ Each row is the port, the process holding it, and its process ID. An (i) beside 
 
 If a listener's address has names pointing at it in your Mac's own hosts file, Netfox shows them next to the port — the local sites, staging environments and side projects you set up months ago and forgot were still running.
 
-One thing to read correctly: a hosts entry points at an **address**, not at a port. A single name on `127.0.0.1` therefore applies to *every* loopback listener, and appears on every one of those rows — accurately, since the name does reach them all, but without telling them apart. The name is a lead, not a label: with several aliases it narrows things down, with exactly one it mostly reminds you the file exists.
+One thing to read correctly: a hosts entry points at an **address**, not at a port. The names you have on `127.0.0.1` and `::1` are shown against every listener that is loopback-only — and against every listener bound to all interfaces too, because a wildcard bind answers on loopback as well, which is exactly how `shop.local:3000` reaches a server listening on `*`.
+
+So a single alias turns up on a lot of rows at once: accurate, since the name really does reach each of them, but not something that tells them apart. The name is a lead, not a label — with several aliases it narrows things down, with exactly one it mostly reminds you the file exists.
 
 <Callout type="info">
 Nothing here needs a password, a permission prompt or a helper. Netfox reads what the system already knows about your own machine. Your own listeners come back complete; ones belonging to other user accounts or to the system may be partial, which is the cost of not asking for privileges. The whole tab is masked in [Demo Mode](/docs/settings#privacy) — a list of running processes is a software inventory, so process names, IDs and hosts-file names are all hidden before you share a screenshot.


### PR DESCRIPTION
Brings the site to 0.16.5 — and while checking what needed updating, two things turned out to be wrong rather than merely stale.

## The macOS floor was wrong in six places

The site said **"macOS 15+"** or **"macOS 15 (Sequoia)"** in six places and 15.6 in none:

| where | what it said |
|---|---|
| `components/Welcome/Welcome.tsx` ×4 | hero badge, download CTA, feature copy, footer line |
| `components/FAQ/FAQ.tsx` | the requirements answer |
| `content/index.mdx` | the Requirements list |

Three independent sources say the floor is **15.6**: `MACOSX_DEPLOYMENT_TARGET` in the app's pbxproj, `LSMinimumSystemVersion` in the shipped binary, and `sparkle:minimumSystemVersion` in the published appcast.

So anyone on 15.0–15.5 was being told the app runs on their Mac. It does not: Sparkle would never offer them the update, and the binary would not launch. That is the worst shape for a marketing claim — it fails after the download.

It drifted in by being copied from FinderGit, whose floor genuinely is different. `CLAUDE.md` now records the rule and where to take the value from, so the next edit doesn't reintroduce it.

## Two claims promised more than the app does

A hosts entry points at an **address**, not a port. One name on `127.0.0.1` therefore applies to *every* loopback listener and shows up on every one of those rows — accurate, since the name does reach them all, but it does not tell them apart.

Both of these implied a per-service association that only exists if you keep several aliases:

- homepage/docs: *"`3000` reads as `shop.local:3000`"*
- Devices page: *"this is where a list of numbers turns into a list of **things**"*

They now describe what the name actually is — a lead, not a label — and the Devices page explains the address-not-port distinction outright. This matches the open issue on the app side rather than papering over it.

## Also

Roadmap says **0.16.5 is live** instead of the 0.16 family, and its Local Services bullet is reworded for the same accuracy reason.

## Verification

- `next build` ✓, `tsc --noEmit` clean, oxlint clean, oxfmt reports correct format
- Served a production build locally and grepped the rendered DOM for each change: homepage now renders `macOS 15.6+` ×3 and `macOS 15.6 Sequoia` ×1, `/docs` renders `macOS 15.6 (Sequoia)`, the roadmap renders `0.16.5`, and both reworded passages are present
- No `macOS 15+` / `macOS 15 (Sequoia)` left anywhere in `.tsx`/`.ts`/`.mdx`

The appcast, `config/index.ts` and `public/release-notes/0.16.5.html` were already updated by the release itself and are not part of this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the minimum supported macOS version to 15.6+ across FAQs, product messaging, and documentation.
  * Clarified that local service entries show their owning process, reachability scope, and hosts-file name for loopback addresses.
  * Clarified that hosts-file names identify listener addresses and may appear across multiple ports.
  * Updated the current release reference to Netfox 0.16.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->