### PR TITLE
fix: date releases by publication, and correct three wrong version claims

### DIFF
--- a/components/ReleaseNotes/ReleaseNotes.tsx
+++ b/components/ReleaseNotes/ReleaseNotes.tsx
@@ -56,7 +56,7 @@ export function ReleaseNotes() {
             title={<Badge size="xl">{release.tag_name}</Badge>}
           >
             <Text size="sm" fw={800} mb={16}>
-              {release.created_at}
+              {release.displayDate}
             </Text>
             <MDXRemote compiledSource={release.body} components={components} />
           </Timeline.Item>

--- a/components/ReleaseNotes/format-release-date.test.ts
+++ b/components/ReleaseNotes/format-release-date.test.ts
@@ -1,0 +1,24 @@
+import { formatReleaseDate } from './format-release-date';
+
+// The suite runs in Pacific/Auckland (pinned in jest.global-setup.cjs, since a
+// beforeAll is too late to affect Intl). That zone is ahead of UTC, so the first
+// case below renders "July 31, 2026" without the UTC pin and this file goes red.
+// Under UTC — or under Europe/Rome, which agrees with UTC for these timestamps —
+// it would pass either way and prove nothing.
+describe('formatReleaseDate', () => {
+  it('keeps an evening-UTC publication on its own calendar date', () => {
+    // v0.15.0, published 18:03 UTC, which is already 31 July local in Auckland.
+    expect(formatReleaseDate('2026-07-30T18:03:22Z', '2026-07-30T07:46:45Z')).toBe('July 30, 2026');
+  });
+
+  it('dates a release by publication, not by the commit its tag points at', () => {
+    // v0.16.6: tagged on the previous release's commit (5 August), shipped 20 August.
+    expect(formatReleaseDate('2026-08-20T11:21:23Z', '2026-08-05T11:58:34Z')).toBe(
+      'August 20, 2026'
+    );
+  });
+
+  it('falls back to the created date for a draft, which has no publication date', () => {
+    expect(formatReleaseDate(null, '2026-08-05T11:58:34Z')).toBe('August 5, 2026');
+  });
+});

--- a/components/ReleaseNotes/format-release-date.ts
+++ b/components/ReleaseNotes/format-release-date.ts
@@ -1,0 +1,24 @@
+/**
+ * The calendar date to show for a release.
+ *
+ * Two decisions, both of which cost a wrong date on the live site:
+ *
+ * - `publishedAt`, never `createdAt`. GitHub reports `created_at` as the date of
+ *   the commit the tag points at, and the release script creates the GitHub
+ *   Release *before* it commits the appcast and config — so the tag lands on the
+ *   previous release's commit and `created_at` carries that release's date.
+ *   v0.16.6 shipped on 20 August and the timeline dated it 5 August, as did every
+ *   0.16.x before it. `createdAt` stays as the fallback because a draft release
+ *   has no `published_at`.
+ * - Pinned to UTC. This is the calendar date of an event, not a local clock
+ *   reading, so it must not move with whoever is reading it: v0.15.0 was
+ *   published 18:03 UTC and renders as 31 July in New Zealand without this.
+ */
+export function formatReleaseDate(publishedAt: string | null, createdAt: string): string {
+  return new Date(publishedAt ?? createdAt).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}

--- a/components/ReleaseNotes/use-release-notes.ts
+++ b/components/ReleaseNotes/use-release-notes.ts
@@ -38,7 +38,10 @@ export interface Release {
   draft: boolean;
   prerelease: boolean;
   created_at: string;
-  published_at: string;
+  /** Null on a draft release, which is why every read of it needs a fallback. */
+  published_at: string | null;
+  /** `published_at` formatted for display. Set by `useReleaseNotes`. */
+  displayDate?: string;
   assets: any[];
   tarball_url: string;
   zipball_url: string;
@@ -76,11 +79,15 @@ export function useReleaseNotes() {
         const releases = await Promise.all(
           data.releases.map(async (release) => ({
             ...release,
-            created_at: new Date(release.created_at).toLocaleDateString('en-US', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            }),
+            // `published_at`, NOT `created_at`. GitHub reports `created_at` as the
+            // date of the *commit the tag points at*, and the release script creates
+            // the GitHub Release before it commits the appcast + config — so the tag
+            // lands on the previous release's commit and `created_at` is that
+            // release's date. v0.16.6 read as August 5 while it shipped on August 20.
+            displayDate: new Date(release.published_at ?? release.created_at).toLocaleDateString(
+              'en-US',
+              { year: 'numeric', month: 'long', day: 'numeric' }
+            ),
             body: await compileMdx(release.body),
           }))
         );

--- a/components/ReleaseNotes/use-release-notes.ts
+++ b/components/ReleaseNotes/use-release-notes.ts
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 import { compileMdx } from 'nextra/compile';
 import useSWR from 'swr';
 
+import { formatReleaseDate } from './format-release-date';
+
 export interface Author {
   login: string;
   id: number;
@@ -79,19 +81,7 @@ export function useReleaseNotes() {
         const releases = await Promise.all(
           data.releases.map(async (release) => ({
             ...release,
-            // `published_at`, NOT `created_at`. GitHub reports `created_at` as the
-            // date of the *commit the tag points at*, and the release script creates
-            // the GitHub Release before it commits the appcast + config — so the tag
-            // lands on the previous release's commit and `created_at` is that
-            // release's date. v0.16.6 read as August 5 while it shipped on August 20.
-            // Pinned to UTC: this is the calendar date of an event, not a local
-            // clock reading, so it must not move with the reader. v0.15.0 was
-            // published 18:03 UTC and rendered as July 31 in New Zealand
-            // (measured) while GitHub itself shows July 30.
-            displayDate: new Date(release.published_at ?? release.created_at).toLocaleDateString(
-              'en-US',
-              { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' }
-            ),
+            displayDate: formatReleaseDate(release.published_at, release.created_at),
             body: await compileMdx(release.body),
           }))
         );

--- a/components/ReleaseNotes/use-release-notes.ts
+++ b/components/ReleaseNotes/use-release-notes.ts
@@ -84,9 +84,13 @@ export function useReleaseNotes() {
             // the GitHub Release before it commits the appcast + config — so the tag
             // lands on the previous release's commit and `created_at` is that
             // release's date. v0.16.6 read as August 5 while it shipped on August 20.
+            // Pinned to UTC: this is the calendar date of an event, not a local
+            // clock reading, so it must not move with the reader. v0.15.0 was
+            // published 18:03 UTC and rendered as July 31 in New Zealand
+            // (measured) while GitHub itself shows July 30.
             displayDate: new Date(release.published_at ?? release.created_at).toLocaleDateString(
               'en-US',
-              { year: 'numeric', month: 'long', day: 'numeric' }
+              { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' }
             ),
             body: await compileMdx(release.body),
           }))

--- a/config/index.ts
+++ b/config/index.ts
@@ -89,7 +89,11 @@ export default {
   },
   app: {
     version: '0.16.6',
-    minMacOS: '15.0',
+    // 15.6, not 15.0: it is the pbxproj MACOSX_DEPLOYMENT_TARGET and the
+    // appcast's sparkle:minimumSystemVersion. Only StructuredData reads this,
+    // so a wrong value here is invisible on the page and still published to
+    // search engines as the supported OS.
+    minMacOS: '15.6',
     downloadUrl: 'https://github.com/gfazioli/netfox-website/releases/latest',
   },
 } as const;

--- a/content/roadmap.mdx
+++ b/content/roadmap.mdx
@@ -3,6 +3,7 @@ title: Roadmap
 ---
 
 import { RoadmapTimeline } from "@/components/RoadmapTimeline/RoadmapTimeline";
+import config from "@/config";
 
 # Roadmap
 
@@ -14,7 +15,7 @@ Netfox grows one module at a time. Each release ships a focused piece of the big
 
 ## Where we are today
 
-Netfox **0.16.5** is live. The current build covers:
+Netfox **{config.app.version}** is live. The current build covers:
 
 - **Discovery & history** — every device you've ever had on the network is remembered with a timeline, discovered across multiple protocols. The timeline now records **port-state changes** too, so you can see when a service appeared or went away.
 - **Alerts** — new devices, returning devices, risky arrivals, port changes, new services. Inbox + history + per-device mute, and the port-opened alert can optionally include your own Mac.
@@ -29,7 +30,7 @@ Netfox **0.16.5** is live. The current build covers:
 - **Device identity** — devices are identified by the model they announce about themselves rather than guessed from their name, and the manufacturer comes from the full public hardware registry. A randomized address says "Private address" rather than leaving the field blank.
 - **Network settings** — what your network hands out to everything on it: the network name, address range, router, name servers, domain and lease, on the Overview. Each device shows the roles it plays — gateway, name resolver, address server.
 - **Link quality** — the round trip to each device, how steady it is, how often it doesn't answer, and a chart of the day. Not the device's own signal, which only the device can measure: the path between your Mac and it.
-- **Local services** — what's listening on your own Mac, including the loopback-only ports a network check structurally cannot see. Each row names the process behind it and how far it reaches, so a forgotten dev server on localhost is something you can find; where your hosts file gives the loopback address a name, that name is shown too.
+- **Local services** — what's listening on your own Mac, including the loopback-only ports a network check structurally cannot see. Each row names the process behind it and how far it reaches, so a forgotten dev server on localhost is something you can find; where your hosts file gives an address a name, that name is shown against the listeners it actually reaches, once above the group rather than on every row.
 - **Menu bar** — a quick-glance popover with your network's status: Devices and Risk as ring gauges, public IP and alerts alongside, plus a live chart of your Mac's traffic, and cards that deep-link straight into the app. Two icon styles: an adaptive monochrome glyph or the colour fox.
 
 ## What's next

--- a/content/tools/wifi.mdx
+++ b/content/tools/wifi.mdx
@@ -79,4 +79,4 @@ Two natural limits:
 
 ## What's coming
 
-The current build is the **scan + history** version. The next major module expands the tool into proper Wi-Fi diagnostics — channel congestion warnings, hidden network detection, neighbour-AP interference analysis. See the [Roadmap](/docs/roadmap) for the full plan.
+The current build is the **scan + history** version. The next major module expands the tool into proper Wi-Fi diagnostics — channel occupancy, congestion warnings and neighbour-AP interference analysis. Hidden networks already show up in the list, as described above; what's missing is what they mean for the channel they sit on. See the [Roadmap](/docs/roadmap) for the full plan.

--- a/content/tools/wifi.mdx
+++ b/content/tools/wifi.mdx
@@ -79,4 +79,4 @@ Two natural limits:
 
 ## What's coming
 
-The current build is the **scan + history** version. The next major module (planned for v0.6) expands the tool into proper Wi-Fi diagnostics — channel congestion warnings, hidden network detection, neighbour-AP interference analysis. See the [Roadmap](/docs/roadmap) for the full plan.
+The current build is the **scan + history** version. The next major module expands the tool into proper Wi-Fi diagnostics — channel congestion warnings, hidden network detection, neighbour-AP interference analysis. See the [Roadmap](/docs/roadmap) for the full plan.

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -5,6 +5,8 @@ const createJestConfig = nextJest({
 });
 
 const customJestConfig = {
+  // Pins the suite's time zone before any worker initialises ICU — see the file.
+  globalSetup: '<rootDir>/jest.global-setup.cjs',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.cjs'],
   moduleNameMapper: {
     '^@/components/(.*)$': '<rootDir>/components/$1',

--- a/jest.global-setup.cjs
+++ b/jest.global-setup.cjs
@@ -1,0 +1,15 @@
+// The test suite runs in a zone that is AHEAD of UTC, on purpose.
+//
+// Date bugs hide in a zone whose offset happens to agree with UTC for the
+// timestamps under test: Europe/Rome (UTC+2 in summer) renders an 18:03 UTC
+// publication on its own calendar date, so a formatter that forgot to pin a
+// zone still looked correct. Pacific/Auckland (UTC+12/+13) does not agree, and
+// the release-date tests fail without the pin.
+//
+// It has to be set here rather than in a `beforeAll`: by the time a test body
+// runs, the worker has already initialised ICU and re-reading process.env.TZ
+// has no effect on Intl (measured — resolvedOptions() kept reporting the
+// original zone). Workers inherit this env when they are forked.
+module.exports = async () => {
+  process.env.TZ = 'Pacific/Auckland';
+};


### PR DESCRIPTION
Two of these were spotted on the live site; the third turned up while checking them and is the one that matters most.

## 1. Every release was dated by the commit its tag points at

The timeline read `created_at`. GitHub reports that as the date of the commit the tag points at — and `release.sh` creates the GitHub Release **before** it commits the appcast + config, so each tag lands on the *previous* release's commit. The date shown was therefore always the previous release's date:

| tag | `created_at` (was shown) | `published_at` (now shown) |
|---|---|---|
| v0.16.6 | 2026-08-05 | **2026-08-20** |
| v0.16.5 | 2026-08-05 | 2026-08-05 |
| v0.16.0 | 2026-07-30 | 2026-08-04 |

That is why 0.16.1 through 0.16.6 all read "August 5, 2026": they are tagged on commits from the same two days. Dates on older releases will shift too — to the day each was actually published.

Also fixed along the way: the hook overwrote `created_at` with a formatted string, so the `Release` type declared an ISO date and held `"August 5, 2026"`. The formatted value now has its own `displayDate` field, and `published_at` is typed `string | null` because a draft release has none.

## 2. The roadmap's version was typed by hand

It said 0.16.5 with 0.16.6 shipped. It now reads `config.app.version`, which `release.sh` already bumps as part of every release, so it cannot drift again. It had drifted before — that is what the earlier "bring the public roadmap up to 0.15.0" commit was.

## 3. The JSON-LD told search engines the app runs on macOS 15.0

`config.app.minMacOS` was `15.0`. The deployment target in the pbxproj (all eight build configs) and the appcast's `sparkle:minimumSystemVersion` both say **15.6**.

Its only reader is `StructuredData`, so this never appeared on a page: every piece of visible copy — the docs index, the FAQ, four places in Welcome — already said 15.6. That is precisely why the earlier pass across the visible copy missed it, and it is the worst class of wrong claim, because it fails *after* the download: a user on 15.0–15.5 is told the app runs, while Sparkle would never offer it and the binary would not launch.

## Also

The Wi-Fi page promised the diagnostics module "planned for v0.6" while the app is on 0.16.6. Versions are assigned when a release starts, so the number is dropped rather than corrected. And the Local services bullet now describes where a hosts-file name is shown, which changed in 0.16.6.

## Verification

- `tsc --noEmit` clean, `oxlint` clean, `next build` green (25/25 static pages).
- The roadmap interpolation **renders**, checked in the built HTML rather than assumed: `["Netfox ",["$","strong",null,{"children":"0.16.6"}]," is live` — and zero occurrences of `0.16.5` left on that page.
- The JSON-LD emits `macOS 15.6 or later` in the built output.
- `displayDate` is present in the client chunk and no `release.created_at` read remains for display.
- **Not verified on screen:** the release-notes timeline renders client-side from SWR, so the dates are not in the served HTML and I could not confirm them with a fetch. The transformation itself was checked against the real API payloads (the table above is measured, not assumed). Worth a two-second look at the deployed page.

## Added after the review passes

- **The date is pinned to UTC.** A publication date is the calendar date of an event, so it must not move with the reader: v0.15.0, published 18:03 UTC, rendered as *July 31* in New Zealand. Raised by the local review pass before push, and independently by CodeRabbit here.
- **It has a test now, and the test can fail.** The formatting moved into `formatReleaseDate` so it is testable without `swr` / `nextra/compile`. Worth stating why the test file pins a zone in `globalSetup`: the first version of the test **passed with the fix removed**, because setting `process.env.TZ` in a `beforeAll` does nothing to `Intl` — the worker has already initialised ICU, and `resolvedOptions()` kept reporting `Europe/Rome`, which agrees with UTC for these timestamps. Pinned before the workers start, deleting `timeZone: 'UTC'` now turns the suite red.
- **The Wi-Fi page no longer promises hidden-network detection as future work** — the same page says twenty lines earlier that a hidden network already appears in the list. What is missing is what it means for the channel it occupies, and the sentence now says that.
- **One finding declined:** replacing "hosts file" with generic wording in the roadmap copy. The no-infra guideline is about naming *our* stack (its examples are Sparkle, framework names); a hosts file is the reader's own file and the subject of the feature. `content/tools/devices.mdx` already names it in copy that shipped with 0.16.6, and the phrase predates this PR. Reasoning is on the thread.

Gate after all of it: `tsc` clean, `oxlint` clean, `oxfmt --check` clean, jest **2 suites / 4 tests** green, `next build` green.
