### PR TITLE
docs(roadmap): Wi-Fi diagnostics has shipped, so it leaves the list

### DIFF
--- a/components/RoadmapTimeline/RoadmapTimeline.tsx
+++ b/components/RoadmapTimeline/RoadmapTimeline.tsx
@@ -24,22 +24,9 @@ const tierColor: Record<Tier, string> = {
 
 const modules: { icon: ReactNode; title: string; tier: Tier; body: ReactNode }[] = [
   {
-    icon: <IconWifi size={18} />,
-    title: 'Wi-Fi diagnostics',
-    tier: 'Up next',
-    body: (
-      <>
-        The Wi-Fi tab today is a basic neighbour list. The next module turns it into a real
-        diagnostics tool: signal-strength history, channel usage, congestion warnings, hidden
-        network detection. Goal: answer &ldquo;is my Wi-Fi the problem?&rdquo; without leaving
-        Netfox.
-      </>
-    ),
-  },
-  {
     icon: <IconPlugConnected size={18} />,
     title: 'Link diagnostics',
-    tier: 'Then',
+    tier: 'Up next',
     body: (
       <>
         Physical-layer health. Cable speed negotiation, duplex mismatch warnings, NIC stats, route
@@ -51,7 +38,7 @@ const modules: { icon: ReactNode; title: string; tier: Tier; body: ReactNode }[]
   {
     icon: <IconChartArea size={18} />,
     title: 'Bandwidth monitor',
-    tier: 'Later',
+    tier: 'Then',
     body: (
       <>
         Per-device traffic accounting in real time. The biggest single lift on the roadmap because


### PR DESCRIPTION
Wi-Fi diagnostics ships in Netfox 0.17.0 — channel occupancy, the plain-English congestion verdict, hidden networks counted toward the picture rather than only labelled — so it comes off the public "what next" timeline, the same way Local Services did when 0.16 shipped it. The modules behind it move up in the order `ROADMAP.md` already declares: link diagnostics, then the bandwidth monitor.

**Merge this before running release.sh.** The release script stages `content/` and `public/screenshot-*.png` only, never `components/`, so a component change left for the release motion does not ship at all. That is the mechanism which let this page sit five minors behind the app before.

The docs pages for the same release (`content/tools/wifi.mdx`, `content/tools/devices.mdx`) are deliberately NOT here: those live in `content/`, so release.sh picks them up from the working tree and they land in the release commit alongside the binary.

`yarn build` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the roadmap to feature “Link diagnostics” as an upcoming item.
  * Removed the “Wi-Fi diagnostics” module from the roadmap.
  * Moved “Bandwidth monitor” from “Later” to “Then.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->