### PR TITLE
docs: promise what the link module can actually find

### DIFF
--- a/components/RoadmapTimeline/RoadmapTimeline.tsx
+++ b/components/RoadmapTimeline/RoadmapTimeline.tsx
@@ -29,9 +29,10 @@ const modules: { icon: ReactNode; title: string; tier: Tier; body: ReactNode }[]
     tier: 'Up next',
     body: (
       <>
-        Physical-layer health. Cable speed negotiation, duplex mismatch warnings, NIC stats, route
-        latency. For people who plug their Mac in and want to know whether the wall jack is letting
-        them down.
+        Physical-layer health. What your Ethernet port negotiated against what it is capable
+        of &mdash; a 10-gigabit port settling for 1 is worth knowing, and the switch or the cable
+        is usually why &mdash; plus link error counters and route latency. For people who plug
+        their Mac in and want to know whether they are getting what they paid for.
       </>
     ),
   },

--- a/components/RoadmapTimeline/RoadmapTimeline.tsx
+++ b/components/RoadmapTimeline/RoadmapTimeline.tsx
@@ -22,6 +22,11 @@ const tierColor: Record<Tier, string> = {
   Backlog: 'gray',
 };
 
+// The same module list lives in two other places and each drifts on its own:
+// content/tools/optimization.mdx, and the app's own Optimization screen
+// (Netfox/OptimizationSection.swift). Wi-Fi diagnostics shipped in 0.17.0 and
+// went on reading "Up next" in the app for a full release, because nothing
+// connects the three. Move one, move all three.
 const modules: { icon: ReactNode; title: string; tier: Tier; body: ReactNode }[] = [
   {
     icon: <IconPlugConnected size={18} />,

--- a/content/tools/optimization.mdx
+++ b/content/tools/optimization.mdx
@@ -15,6 +15,13 @@ This tool intentionally doesn't ship functionality yet. Each module under it nee
 
 ## What's coming
 
+{/* This list exists THREE times and each copy drifts on its own: here, in
+    components/RoadmapTimeline/RoadmapTimeline.tsx, and in the app itself
+    (Netfox/OptimizationSection.swift). Wi-Fi diagnostics shipped in 0.17.0
+    and stayed "Up next" in all three for a full release. Move one, move all
+    three -- and a shipped module leaves the app's list entirely, since that
+    one answers "what is not built yet" rather than "what happened". */}
+
 | Module | Status | Notes |
 |---|---|---|
 | **Wi-Fi diagnostics** | Shipped in v0.17.0 | Channel congestion, neighbour-AP interference, hidden network detection, and a plain-English verdict on whether your Wi-Fi is the problem — built into today's [Wi-Fi](/docs/tools/wifi) tool |

--- a/content/tools/optimization.mdx
+++ b/content/tools/optimization.mdx
@@ -1,28 +1,28 @@
 ---
 title: "Optimization"
-description: "What's next for Netfox: Wi-Fi diagnostics, link diagnostics and a bandwidth monitor — a preview of the upcoming optimization tools."
+description: "What's next for Netfox: link diagnostics and a bandwidth monitor — a preview of the upcoming optimization tools."
 ---
 
 import { Callout } from 'nextra/components';
 
 # Optimization
 
-The **Optimization** tool is a placeholder today — a preview of the modules planned for the next versions. Opening it shows a list of upcoming features with their target version, plus a link to the full [Roadmap](/docs/roadmap).
+The **Optimization** tool is a placeholder today — a preview of the modules still to come. Opening it shows the upcoming features in the order they are planned, plus a link to the full [Roadmap](/docs/roadmap).
 
 <Callout type="info">
-This tool intentionally doesn't ship functionality yet. Each module under it needs either a privileged background helper or new core providers before it can earn its space. Shipping the slot empty (with the roadmap inside) tells users "yes, this is coming — here's when" instead of hiding the plan.
+This tool intentionally doesn't ship functionality yet. Each module under it needs either a privileged background helper or new core providers before it can earn its space. Shipping the slot empty (with the roadmap inside) tells users "yes, this is coming, and here is what is next" instead of hiding the plan.
 </Callout>
 
 ## What's coming
 
-| Module | Target | Notes |
+| Module | Status | Notes |
 |---|---|---|
-| **Wi-Fi diagnostics** | v0.6 | Channel congestion, signal-history scoring, hidden network detection, neighbour-AP interference — extension of today's [Wi-Fi](/docs/tools/wifi) tool |
-| **Link diagnostics** | v0.7 | Physical-layer health: NIC stats, cable speed negotiation, duplex mismatch warnings, route latency |
-| **Bandwidth monitor** | v0.8 | Per-device traffic accounting in real time. Needs a privileged background helper to read packet metadata — the biggest single lift on the roadmap. The menu bar's [traffic chart](/docs/menu-bar#live-traffic) already covers your own Mac |
+| **Wi-Fi diagnostics** | Shipped in v0.17.0 | Channel congestion, neighbour-AP interference, hidden network detection, and a plain-English verdict on whether your Wi-Fi is the problem — built into today's [Wi-Fi](/docs/tools/wifi) tool |
+| **Link diagnostics** | Up next | Physical-layer health: what your Ethernet port negotiated against what it can do — a 10-gigabit port settling for 1 is worth knowing, and the switch or the cable is usually why — plus link error counters and route latency |
+| **Bandwidth monitor** | Then | Per-device traffic accounting in real time. Needs a privileged background helper to read packet metadata — the biggest single lift on the roadmap. The menu bar's [traffic chart](/docs/menu-bar#live-traffic) already covers your own Mac |
 | **Speed test** | Backlog | Built-in download / upload / latency / jitter / packet-loss benchmark |
 
-Versions aren't promised dates — they're the version we're aiming to land each in. See the [Roadmap](/docs/roadmap) for the longer narrative and what comes after v0.8.
+**The order is the promise, not a version number.** Each module lands in whatever version is current when it's ready, so this table tracks status rather than a target — a number written here ages badly the moment a release slips or arrives early. See the [Roadmap](/docs/roadmap) for the longer narrative and what comes after these.
 
 ## Why a placeholder tool, not just docs
 


### PR DESCRIPTION
Rewrites what the **Link diagnostics** module promises, now that both machines have been measured, and fixes version targets that had gone ten minors stale.

## Duplex mismatch is not a thing this hardware can do

Measured across every interface of a Mac Studio and a MacBook Pro: **not one advertises a half-duplex mode** among its supported media. That is not "no data" — it is hardware that cannot enter the state the page warns about. And a real mismatch surfaces as error counters, never as a readable flag, so the warning could not have been built as written.

## What replaces it is better, and it exists

A Mac Studio's port advertises up to **10Gbase-T** and settles on **1000baseT**. "Your 10-gigabit port negotiated 1 — check the switch and the cable" is a real, actionable finding on a real machine. The module gains a better promise than the one it loses.

Error counters stay, but as *link health* rather than as a headline: on both Macs they read zero across 19M packets, so leading with them would promise an empty screen.

## The version targets contradicted the component next to them

The table promised **Wi-Fi diagnostics in v0.6** (it shipped in **0.17.0**) and **Link diagnostics in v0.7**.

Worth naming because it is the interesting half: `RoadmapTimeline.tsx` says in its own header that it carries **no version numbers by design** — *"the order is the promise"* — and it had already dropped Wi-Fi diagnostics. So the two surfaces disagreed, and the one holding hand-written numbers was the one that drifted. Same shape as the `roadmap.mdx` version that was left two releases behind twice, which is why it now reads `config.app.version`.

The table now tracks **status** against the tiers the timeline already uses (Up next / Then / Backlog). Only the shipped row keeps a version, because a past fact cannot go stale.

## Three carriers a grep could not have found

Searching the old wording finds the table and the component. It cannot find these, all in the same page and all now fixed:

- the frontmatter `description` still listed Wi-Fi diagnostics among what is coming;
- the intro said the tool shows features "with their target version";
- the callout said shipping the slot empty tells users *"yes, this is coming — here's when"*.

## Verified

`tsc --noEmit` clean. `duplex` now appears nowhere in `content/` or `components/`, and the only `v0.x` left in `content/` is the shipped Wi-Fi row.

## Follow-up, different repo

The same list exists a **third** time, inside the app: `OptimizationSection.swift` renders "Wi-Fi diagnostics — Up next" and "Link diagnostics — Then". So the shipped app tells users its own headline 0.17.0 feature has not been built yet. Fixed separately in the Netfox repo, since it is app code and needs the six translations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Optimization page to show planned modules by delivery order and current status rather than target versions.
  * Clarified Wi‑Fi diagnostics capabilities and the planned sequence for Link diagnostics, Bandwidth monitor, and Speed test.
  * Refined the Link diagnostics roadmap description to cover Ethernet speed negotiation, link errors, and route latency.
  * Added guidance that delivery order is not tied to specific versions and linked to the Roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->