### PR TITLE
fix(home): restore the space eaten between the version and its separator

### DIFF
--- a/components/Welcome/Welcome.tsx
+++ b/components/Welcome/Welcome.tsx
@@ -371,8 +371,25 @@ export function Welcome() {
 
             <Stack gap={4} align="center" mt={8}>
               <Text c="dimmed" ta="center" size="sm">
-                Free &middot; v{config.app.version} &middot; macOS 15.6+ &middot; Universal (Apple
-                Silicon + Intel) &middot; Signed &amp; notarized
+                {/*
+                  One interpolated string rather than JSX text, because the
+                  JSX version shipped as "v0.17.1· macOS 15.6+": in a text
+                  chunk spanning more than one line, the space between an
+                  interpolation and a following HTML ENTITY is dropped.
+                  Measured on the live site and reproduced in a probe route -
+                  a plain character in the same position keeps its space, and
+                  so does the entity while the chunk fits on one line, so it
+                  takes both the entity and the wrap.
+
+                  Fixing it with an explicit {' '} does not hold: oxfmt
+                  removes it and rejoins the lines, which is why the defect
+                  survived on the homepage. A template literal puts the
+                  separators inside a string, where neither the formatter nor
+                  the JSX whitespace rules can reach them.
+
+                  Ported from findergit-website, where this was found.
+                */}
+                {`Free · v${config.app.version} · macOS ${config.app.minMacOS}+ · Universal (Apple Silicon + Intel) · Signed & notarized`}
               </Text>
               <Anchor href="/docs/release-notes" c="dimmed" size="sm">
                 Release notes


### PR DESCRIPTION
Backport of the same one-line defect fixed in findergit-website#53, found there and confirmed here.

**netfox.app is live right now as `v0.17.1· macOS 15.6+`** — no space before the separator:

```
$ curl -s "https://netfox.app/?v=$(date +%s)" | grep -oE 'Free · v<!-- -->[0-9.]+<!-- -->.{0,18}'
Free · v<!-- -->0.17.1<!-- -->· macOS 15.6+ · Un
```

## The cause, isolated

It needs **all three** of: a JSX text chunk spanning more than one source line, a leading space, and an HTML entity immediately after an interpolation. Reproduced in a probe route built by the sibling project's own pipeline:

| source shape | result |
|---|---|
| `A &middot; v{v} &middot; macOS` over two lines | `0.28.0· macOS` — space **lost** |
| `B - v{v} - macOS` over two lines | space kept |
| `C &middot; v{v} then macOS` over two lines | space kept |
| `D &middot; v{v} &middot; macOS` on **one** line | space kept |

**The obvious fix does not survive.** An explicit `{' '}` is removed by oxfmt, which then rejoins the lines — presumably how this got in, and why it stayed on both sites. So the separators move inside a template literal, where neither the formatter nor the JSX whitespace rules can reach them.

Grepped for the class rather than the instance: `}` followed by a space and an entity appears exactly once here, same as on the sibling.

## One carrier fewer, while the line was open

The macOS floor now reads `config.app.minMacOS` instead of repeating `15.6` in the markup. This site has paid twice for keeping a second copy of that number: six pages claimed `macOS 15+` against a binary whose `MACOSX_DEPLOYMENT_TARGET` is 15.6 — a claim that fails *after* the download — and the pass that fixed those left `config.app.minMacOS` itself at `15.0`, where only the JSON-LD reads it, so search engines were told the wrong floor while every visible string was right.

Checked before wiring it up: `config.app.minMacOS` is `15.6`, `MACOSX_DEPLOYMENT_TARGET = 15.6`, and the current appcast entries say `15.6`. Rendered output is byte-identical to the literal it replaces.

## Verified

Production build, before and after on the same line:

```
PRIMA (live):  Free · v0.17.1· macOS 15.6+ · Universal (Apple Silicon + Intel) · Signed &amp; notarized
DOPO  (build): Free · v0.17.1 · macOS 15.6+ · Universal (Apple Silicon + Intel) · Signed &amp; notarized
```

`tsc --noEmit` clean, 4 tests green, build exit 0 with zero errors.

**Pre-existing, not touched:** `components/RoadmapTimeline/RoadmapTimeline.tsx` fails `oxfmt --check` on `main` as well — confirmed by stashing this change and re-running. Left alone so this branch stays one topic; worth a `format:write` pass on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the welcome screen’s version and system requirements text to display current application configuration values.
  - Improved formatting consistency for the version and minimum macOS information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->