### PR TITLE
feat(home): show how recently, and how often, Netfox ships

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,16 @@
+import { fetchReleaseCadence } from '@/components/ReleaseCadence/fetch-release-cadence';
 import { Welcome } from '@/components/Welcome/Welcome';
 
-export default function HomePage() {
-  return <Welcome />;
+/**
+ * Regenerated hourly so the hero's release strip stays honest between
+ * deploys. Without it the page is built once per release and its relative
+ * freshness phrase ("Updated today") would freeze at whatever it said on
+ * release day, which is precisely the failure the strip is meant to avoid.
+ */
+export const revalidate = 3600;
+
+export default async function HomePage() {
+  const cadence = await fetchReleaseCadence();
+
+  return <Welcome cadence={cadence} />;
 }

--- a/components/ReleaseCadence/ReleaseCadence.module.css
+++ b/components/ReleaseCadence/ReleaseCadence.module.css
@@ -1,0 +1,47 @@
+/*
+ * Sits on the hero's Scene wash (mesh + two glows + dotgrid), so the surface
+ * is translucent with a blur behind it rather than a flat fill: an opaque
+ * pill would punch a hole in the atmosphere it sits on. light-dark() keeps
+ * it legible on the white light-mode page and on dark-7.
+ */
+.strip {
+  background: light-dark(rgb(255 255 255 / 65%), rgb(255 255 255 / 4%));
+  border-color: light-dark(rgb(0 0 0 / 8%), rgb(255 255 255 / 8%));
+  backdrop-filter: blur(6px);
+}
+
+/*
+ * Teal rather than the page's blue: the strip has to read as a status light,
+ * and blue would merge into the brand wash behind it.
+ */
+.dot {
+  flex: none;
+  width: rem(8px);
+  height: rem(8px);
+  border-radius: 50%;
+  background: var(--mantine-color-teal-5);
+  box-shadow: 0 0 0 rem(4px) color-mix(in srgb, var(--mantine-color-teal-5) 22%, transparent);
+  animation: cadence-pulse 2.4s ease-in-out infinite;
+}
+
+/*
+ * The halo breathes, the dot does not move: animating the box-shadow spread
+ * would relayout nothing but does force a paint on a blurred surface, and
+ * transform-scaling the dot makes the text baseline appear to wobble.
+ */
+@keyframes cadence-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 rem(3px) color-mix(in srgb, var(--mantine-color-teal-5) 14%, transparent);
+  }
+
+  50% {
+    box-shadow: 0 0 0 rem(6px) color-mix(in srgb, var(--mantine-color-teal-5) 30%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dot {
+    animation: none;
+  }
+}

--- a/components/ReleaseCadence/ReleaseCadence.test.tsx
+++ b/components/ReleaseCadence/ReleaseCadence.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@/test-utils';
+import { ReleaseCadence } from './ReleaseCadence';
+
+const FRESH = {
+  freshness: 'Updated today',
+  latestDate: 'August 31, 2026',
+  total: 47,
+  since: 'April 2026',
+} as const;
+
+describe('ReleaseCadence', () => {
+  it('leads with the freshness phrase and backs it with the count', () => {
+    render(<ReleaseCadence cadence={FRESH} />);
+    expect(screen.getByText('Updated today')).toBeInTheDocument();
+    expect(screen.getByText(/47 releases since April 2026/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /what's new/i })).toHaveAttribute(
+      'href',
+      '/docs/release-notes'
+    );
+  });
+
+  it('states the plain date once the release is too old to sell as fresh', () => {
+    render(<ReleaseCadence cadence={{ ...FRESH, freshness: null }} />);
+    expect(screen.getByText('Latest release August 31, 2026')).toBeInTheDocument();
+  });
+
+  it('drops the count line rather than printing a number it does not have', () => {
+    // The degraded path: the releases API failed and the strip is running off
+    // the config date alone. Printing "0 releases" here would say the app has
+    // never shipped.
+    render(<ReleaseCadence cadence={{ ...FRESH, total: null, since: null }} />);
+    expect(screen.queryByText(/releases since/)).not.toBeInTheDocument();
+    expect(screen.getByText('Updated today')).toBeInTheDocument();
+  });
+});

--- a/components/ReleaseCadence/ReleaseCadence.tsx
+++ b/components/ReleaseCadence/ReleaseCadence.tsx
@@ -1,0 +1,51 @@
+import { Anchor, Group, Paper, Stack, Text } from '@mantine/core';
+import type { ReleaseCadence as Cadence } from './release-cadence';
+import classes from './ReleaseCadence.module.css';
+
+/**
+ * The "still being worked on" strip under the hero download buttons.
+ *
+ * It carries no version number on purpose: the meta line directly above
+ * already prints `v{config.app.version}`, and two versions 40px apart is one
+ * more place for them to disagree. This element answers a different question -
+ * how recently, and how often.
+ */
+export function ReleaseCadence({ cadence }: { cadence: Cadence }) {
+  const { freshness, latestDate, total, since } = cadence;
+  const isFresh = freshness !== null;
+
+  return (
+    <Paper className={classes.strip} radius="xl" px="xl" py={10} withBorder>
+      <Stack gap={2} align="center">
+        <Group gap={8} wrap="nowrap">
+          {/*
+            The live dot appears only alongside a freshness phrase. Past the
+            staleness cut-off the strip states a plain date instead, and a
+            pulsing "live" indicator next to a months-old date would be
+            asserting something the date itself contradicts.
+          */}
+          {isFresh && <span className={classes.dot} aria-hidden="true" />}
+          <Text size="sm" fw={600}>
+            {isFresh ? freshness : `Latest release ${latestDate}`}
+          </Text>
+        </Group>
+
+        <Group gap={6} wrap="wrap" justify="center">
+          {total !== null && since !== null && (
+            <>
+              <Text size="xs" c="dimmed">
+                {total} releases since {since}
+              </Text>
+              <Text size="xs" c="dimmed" aria-hidden="true">
+                &middot;
+              </Text>
+            </>
+          )}
+          <Anchor href="/docs/release-notes" size="xs" fw={500}>
+            What&apos;s new
+          </Anchor>
+        </Group>
+      </Stack>
+    </Paper>
+  );
+}

--- a/components/ReleaseCadence/fetch-release-cadence.test.ts
+++ b/components/ReleaseCadence/fetch-release-cadence.test.ts
@@ -1,0 +1,123 @@
+import config from '@/config';
+import { fetchReleaseCadence } from './fetch-release-cadence';
+
+const NOW = new Date('2026-08-31T18:00:00Z');
+
+/** One app release, dated `days` before NOW so the ordering is predictable. */
+function release(n: number, days: number) {
+  const at = new Date(NOW.getTime() - days * 86_400_000).toISOString();
+  return { name: `Netfox 0.${n}.0`, tag_name: `v0.${n}.0`, published_at: at };
+}
+
+/** Serves the given pages in order, then empty pages. */
+function servePages(pages: unknown[][]) {
+  let call = 0;
+  return jest.fn(async () => {
+    const body = pages[call] ?? [];
+    call += 1;
+    return { ok: true, json: async () => body } as unknown as Response;
+  });
+}
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  jest.restoreAllMocks();
+});
+
+describe('fetchReleaseCadence', () => {
+  it('counts across pages when the last one is short', async () => {
+    const full = Array.from({ length: 100 }, (_, i) => release(i + 100, i + 200));
+    const tail = Array.from({ length: 7 }, (_, i) => release(i, i + 1));
+    global.fetch = servePages([full, tail]);
+
+    const cadence = await fetchReleaseCadence(NOW);
+    expect(cadence.total).toBe(107);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports NO count when the paging cap is hit with a full page', async () => {
+    // The discriminating case. Five full pages do not prove there is nothing
+    // after them, so summarising them would publish 500 as a total when the
+    // real number is 500-or-more. Before this was guarded the function returned
+    // exactly that.
+    const full = Array.from({ length: 100 }, (_, i) => release(i, i + 1));
+    global.fetch = servePages([full, full, full, full, full]);
+
+    const cadence = await fetchReleaseCadence(NOW);
+    expect(cadence.total).toBeNull();
+    expect(cadence.since).toBeNull();
+    // Still a usable strip: the config date stands in.
+    expect(cadence.latestDate).toContain('2026');
+  });
+
+  it('stops at the cap instead of walking the API forever', async () => {
+    const full = Array.from({ length: 100 }, (_, i) => release(i, i + 1));
+    global.fetch = servePages([full, full, full, full, full, full, full]);
+
+    await fetchReleaseCadence(NOW);
+    expect(global.fetch).toHaveBeenCalledTimes(5);
+  });
+
+  it('falls back on a non-OK response rather than counting what arrived', async () => {
+    const full = Array.from({ length: 100 }, (_, i) => release(i, i + 1));
+    let call = 0;
+    global.fetch = jest.fn(async () => {
+      call += 1;
+      return call === 1
+        ? ({ ok: true, json: async () => full } as unknown as Response)
+        : ({ ok: false, status: 403, json: async () => ({}) } as unknown as Response);
+    });
+
+    const cadence = await fetchReleaseCadence(NOW);
+    expect(cadence.total).toBeNull();
+  });
+
+  it('falls back when the payload is not an array', async () => {
+    global.fetch = jest.fn(
+      async () =>
+        ({
+          ok: true,
+          json: async () => ({ message: 'rate limit exceeded' }),
+        }) as unknown as Response
+    );
+    expect((await fetchReleaseCadence(NOW)).total).toBeNull();
+  });
+
+  it('falls back when the request throws', async () => {
+    global.fetch = jest.fn(async () => {
+      throw new Error('ETIMEDOUT');
+    });
+    expect((await fetchReleaseCadence(NOW)).total).toBeNull();
+  });
+
+  it('ignores the website template releases sharing the repo', async () => {
+    global.fetch = servePages([
+      [
+        release(28, 0),
+        { name: 'v6.0.7', tag_name: 'v6.0.7', published_at: NOW.toISOString() },
+        release(27, 5),
+      ],
+    ]);
+    const cadence = await fetchReleaseCadence(NOW);
+    expect(cadence.total).toBe(2);
+  });
+
+  it('asks GitHub anonymously, so a draft can never be counted', async () => {
+    const spy = servePages([[release(28, 0)]]);
+    global.fetch = spy;
+    await fetchReleaseCadence(NOW);
+    const [, init] = spy.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.stringify(init.headers)).not.toMatch(/authorization/i);
+  });
+
+  it('reads the app releases of the configured repo', async () => {
+    const spy = servePages([[release(28, 0)]]);
+    global.fetch = spy;
+    await fetchReleaseCadence(NOW);
+    const [url] = spy.mock.calls[0] as unknown as [string];
+    expect(url).toContain(config.gitHub.releasesUrl);
+    expect(url).toContain('per_page=100');
+  });
+});

--- a/components/ReleaseCadence/fetch-release-cadence.ts
+++ b/components/ReleaseCadence/fetch-release-cadence.ts
@@ -1,0 +1,93 @@
+import config from '@/config';
+import {
+  fallbackReleaseCadence,
+  type ReleaseCadence,
+  type ReleaseRecord,
+  summariseReleases,
+  toCadence,
+} from './release-cadence';
+
+/** GitHub caps a releases page at 100. 47 app releases as of 0.28.0. */
+const PER_PAGE = 100;
+/**
+ * Hard bound on the paging loop, so a bug cannot walk it forever during a
+ * build. It is NOT a claim that 500 releases are enough: past this many the
+ * function reports no count rather than a floor. 42 as of 0.17.1.
+ */
+const MAX_PAGES = 5;
+const TIMEOUT_MS = 10_000;
+
+/**
+ * The release count and dates behind the homepage strip, read straight from
+ * the GitHub releases API on the server.
+ *
+ * Server-side and not through `/api/github-releases`, for three reasons: that
+ * route slices the payload to the three releases the notes page renders, so it
+ * cannot produce a total; it answers 403 to any user agent that looks like a
+ * crawler, which is exactly who should see the freshness signal; and reaching
+ * it from the client would keep the numbers out of the initial HTML, which on
+ * this site has already once read as a failed deploy.
+ *
+ * Deliberately UNAUTHENTICATED even where GITHUB_TOKEN is set: an
+ * authenticated read can see draft releases, and a draft must not be counted.
+ * Next's data cache plus the page's `revalidate` keep this to roughly one
+ * request an hour, well inside the 60/hr anonymous budget.
+ *
+ * Never throws. Any failure returns the config-derived fallback, so the strip
+ * renders a correct date with no count rather than disappearing.
+ */
+export async function fetchReleaseCadence(now: Date = new Date()): Promise<ReleaseCadence> {
+  try {
+    const collected: ReleaseRecord[] = [];
+    // Only a short page proves there is nothing after it. Exhausting MAX_PAGES
+    // with a full one does not, and a floor presented as a total is exactly the
+    // wrong number this function refuses to print everywhere else.
+    let reachedTheEnd = false;
+
+    for (let page = 1; page <= MAX_PAGES; page += 1) {
+      const response = await fetch(
+        `${config.gitHub.releasesUrl}?per_page=${PER_PAGE}&page=${page}`,
+        {
+          headers: {
+            Accept: 'application/vnd.github+json',
+            'User-Agent': 'netfox-website',
+          },
+          next: { revalidate: 3600 },
+          signal: AbortSignal.timeout(TIMEOUT_MS),
+        }
+      );
+
+      if (!response.ok) {
+        // Bail out entirely rather than summarising what did arrive: a partial
+        // read yields an UNDERCOUNT, and a wrong number on the homepage is
+        // worse than no number. The fallback drops the count line.
+        return fallbackReleaseCadence(now);
+      }
+
+      const batch: unknown = await response.json();
+      if (!Array.isArray(batch)) {
+        return fallbackReleaseCadence(now);
+      }
+
+      collected.push(...(batch as ReleaseRecord[]));
+      if (batch.length < PER_PAGE) {
+        reachedTheEnd = true;
+        break;
+      }
+    }
+
+    if (!reachedTheEnd) {
+      // MAX_PAGES * PER_PAGE releases with the last page still full: there may
+      // be more, and a page count of exactly the cap is indistinguishable from
+      // "more remain". Raising the cap only moves the boundary, so the honest
+      // answer is the same one every other failure gets - state the date, drop
+      // the count.
+      return fallbackReleaseCadence(now);
+    }
+
+    const summary = summariseReleases(collected, config.releaseNotes.appReleaseNamePrefix);
+    return summary ? toCadence(summary, now) : fallbackReleaseCadence(now);
+  } catch {
+    return fallbackReleaseCadence(now);
+  }
+}

--- a/components/ReleaseCadence/release-cadence.test.ts
+++ b/components/ReleaseCadence/release-cadence.test.ts
@@ -1,0 +1,194 @@
+import config from '@/config';
+import {
+  fallbackReleaseCadence,
+  formatFreshness,
+  formatSince,
+  summariseReleases,
+  toCadence,
+} from './release-cadence';
+
+// The suite runs in Pacific/Auckland (pinned in jest.global-setup.cjs), i.e.
+// 12-13 hours AHEAD of UTC. Several cases below only discriminate because of
+// that: under Europe/Rome they would pass against a version of the code that
+// counted local days, which is the bug they exist to catch.
+
+describe('formatFreshness', () => {
+  it('counts days on the UTC calendar, not the reader is own', () => {
+    // Published 23:00 UTC on 31 August, read 01:00 UTC on 1 September: one UTC
+    // day apart. In Auckland BOTH instants fall on 1 September, so a local-day
+    // count returns "Updated today" and this assertion goes red.
+    expect(formatFreshness('2026-08-31T23:00:00Z', new Date('2026-09-01T01:00:00Z'))).toBe(
+      'Updated yesterday'
+    );
+  });
+
+  it('reads the same UTC day as today', () => {
+    expect(formatFreshness('2026-08-31T06:00:00Z', new Date('2026-08-31T22:00:00Z'))).toBe(
+      'Updated today'
+    );
+  });
+
+  it('counts plain days below a week', () => {
+    expect(formatFreshness('2026-08-28T10:00:00Z', new Date('2026-08-31T10:00:00Z'))).toBe(
+      'Updated 3 days ago'
+    );
+  });
+
+  it('collapses the first full week into a phrase rather than a 7', () => {
+    expect(formatFreshness('2026-08-24T10:00:00Z', new Date('2026-08-31T10:00:00Z'))).toBe(
+      'Updated last week'
+    );
+    expect(formatFreshness('2026-08-18T10:00:00Z', new Date('2026-08-31T10:00:00Z'))).toBe(
+      'Updated last week'
+    );
+  });
+
+  it('counts whole weeks after that', () => {
+    expect(formatFreshness('2026-08-10T10:00:00Z', new Date('2026-08-31T10:00:00Z'))).toBe(
+      'Updated 3 weeks ago'
+    );
+  });
+
+  it('stops selling freshness once the gap is two months', () => {
+    // 59 days still reads as a cadence; 60 is where the caller falls back to
+    // the plain date instead of advertising the gap on the homepage.
+    expect(formatFreshness('2026-07-03T10:00:00Z', new Date('2026-08-31T10:00:00Z'))).toBe(
+      'Updated 8 weeks ago'
+    );
+    expect(formatFreshness('2026-07-02T10:00:00Z', new Date('2026-08-31T10:00:00Z'))).toBeNull();
+  });
+
+  it('clamps a release dated in the future instead of counting backwards', () => {
+    expect(formatFreshness('2026-09-02T10:00:00Z', new Date('2026-08-31T10:00:00Z'))).toBe(
+      'Updated today'
+    );
+  });
+
+  it('says nothing at all for an unparseable date', () => {
+    expect(formatFreshness('not a date', new Date('2026-08-31T10:00:00Z'))).toBeNull();
+  });
+});
+
+describe('formatSince', () => {
+  it('keeps a late-evening UTC publication in its own month', () => {
+    // 23:00 UTC on 31 May is already 1 June in Auckland, which would print
+    // "June 2026" and postdate the app is first release by a month.
+    expect(formatSince('2026-05-31T23:00:00Z')).toBe('May 2026');
+  });
+
+  it('returns nothing for an unparseable date', () => {
+    expect(formatSince('')).toBeNull();
+  });
+});
+
+describe('summariseReleases', () => {
+  const prefix = config.releaseNotes.appReleaseNamePrefix;
+
+  it('ignores the website template is own releases', () => {
+    // The app releases share this repo with the Mantine/Nextra template, which
+    // tags a v6.x release of its own whenever its packages are bumped. Counting
+    // those inflates the number the homepage claims.
+    const summary = summariseReleases(
+      [
+        { name: 'Netfox 0.17.1', published_at: '2026-08-28T11:23:59Z' },
+        { name: 'v6.0.7', published_at: '2026-08-27T09:00:00Z' },
+        { name: 'Netfox 0.17.0', published_at: '2026-08-27T08:25:01Z' },
+      ],
+      prefix
+    );
+    expect(summary).toEqual({
+      total: 2,
+      firstISO: '2026-08-27T08:25:01Z',
+      latestISO: '2026-08-28T11:23:59Z',
+    });
+  });
+
+  it('does not count a draft nobody can download', () => {
+    const summary = summariseReleases(
+      [
+        {
+          name: 'Netfox 0.18.0',
+          draft: true,
+          published_at: null,
+          created_at: '2026-08-29T08:00:00Z',
+        },
+        { name: 'Netfox 0.17.1', published_at: '2026-08-28T11:23:59Z' },
+      ],
+      prefix
+    );
+    expect(summary?.total).toBe(1);
+    expect(summary?.latestISO).toBe('2026-08-28T11:23:59Z');
+  });
+
+  it('finds the endpoints in a payload that is not in order', () => {
+    const summary = summariseReleases(
+      [
+        { name: 'Netfox 0.14.0', published_at: '2026-07-30T07:46:41Z' },
+        { name: 'Netfox 0.17.1', published_at: '2026-08-28T11:23:59Z' },
+        { name: 'Netfox 0.1.0', published_at: '2026-05-17T11:52:21Z' },
+      ],
+      prefix
+    );
+    expect(summary?.firstISO).toBe('2026-05-17T11:52:21Z');
+    expect(summary?.latestISO).toBe('2026-08-28T11:23:59Z');
+  });
+
+  it('dates a release by publication, not by the commit its tag points at', () => {
+    // Same trap format-release-date.ts documents: release.sh creates the GitHub
+    // Release before it commits the appcast, so created_at is usually the
+    // PREVIOUS release is commit. Real numbers from 0.16.6, where the two are
+    // FIFTEEN days apart, so dating it by created_at would place it before
+    // four releases that actually shipped earlier.
+    const summary = summariseReleases(
+      [
+        {
+          name: 'Netfox 0.16.6',
+          published_at: '2026-08-20T11:21:23Z',
+          created_at: '2026-08-05T11:58:34Z',
+        },
+      ],
+      prefix
+    );
+    expect(summary?.latestISO).toBe('2026-08-20T11:21:23Z');
+  });
+
+  it('reports nothing rather than zero when the payload matches nothing', () => {
+    // A zero would render "0 releases since ...", which says the app has never
+    // shipped. Null makes the strip drop the count line entirely.
+    expect(
+      summariseReleases([{ name: 'v6.0.7', published_at: '2026-08-27T09:00:00Z' }], prefix)
+    ).toBeNull();
+    expect(summariseReleases([], prefix)).toBeNull();
+  });
+});
+
+describe('toCadence', () => {
+  it('formats the strip is four strings off one summary', () => {
+    expect(
+      toCadence(
+        { total: 42, firstISO: '2026-05-17T11:52:21Z', latestISO: '2026-08-28T11:23:59Z' },
+        new Date('2026-08-28T18:00:00Z')
+      )
+    ).toEqual({
+      freshness: 'Updated today',
+      latestDate: 'August 28, 2026',
+      total: 42,
+      since: 'May 2026',
+    });
+  });
+});
+
+describe('fallbackReleaseCadence', () => {
+  it('takes its date from the config value release.sh writes', () => {
+    // Asserted against config rather than a literal, so the test does not need
+    // editing at every release - and so it stays red if the date is ever
+    // hardcoded in the component instead.
+    const onReleaseDay = new Date(`${config.app.releaseDate}T18:00:00Z`);
+    expect(fallbackReleaseCadence(onReleaseDay).freshness).toBe('Updated today');
+  });
+
+  it('offers no count, because an undercount would be a false claim', () => {
+    expect(fallbackReleaseCadence(new Date()).total).toBeNull();
+    expect(fallbackReleaseCadence(new Date()).since).toBeNull();
+  });
+});

--- a/components/ReleaseCadence/release-cadence.ts
+++ b/components/ReleaseCadence/release-cadence.ts
@@ -1,0 +1,166 @@
+import config from '@/config';
+import { formatReleaseDate } from '@/components/ReleaseNotes/format-release-date';
+
+/**
+ * Everything the homepage release strip renders. Deliberately pre-formatted
+ * strings rather than dates: the strip is a client component, so anything it
+ * receives crosses the server/client boundary, and formatting on the server
+ * keeps a single clock and a single locale in play.
+ */
+export interface ReleaseCadence {
+  /**
+   * How recently the newest release shipped ("Updated today"), or null once it
+   * is old enough that a relative phrase stops being a selling point and
+   * starts advertising the gap. The caller falls back to `latestDate`.
+   */
+  freshness: string | null;
+  /** Always set. Calendar date of the newest release, e.g. "August 31, 2026". */
+  latestDate: string;
+  /** How many app releases have shipped, or null when the live count failed. */
+  total: number | null;
+  /** Month and year of the FIRST app release, e.g. "April 2026". */
+  since: string | null;
+}
+
+/** Shape of the fields this module reads off the GitHub releases API. */
+export interface ReleaseRecord {
+  name?: string | null;
+  tag_name?: string | null;
+  draft?: boolean;
+  created_at?: string | null;
+  published_at?: string | null;
+}
+
+export interface ReleaseSummary {
+  total: number;
+  firstISO: string;
+  latestISO: string;
+}
+
+/**
+ * Past this many days the relative phrase is suppressed. A freshness badge is
+ * an asset while the pace holds and a liability the moment it does not: at
+ * two months the honest thing on the homepage is the plain date, not
+ * "Updated 9 weeks ago" above the fold.
+ */
+const STALE_AFTER_DAYS = 60;
+
+/**
+ * Whole days between two instants, counted on the UTC calendar.
+ *
+ * UTC and not the reader's zone, for the same reason `formatReleaseDate` pins
+ * it: the strip prints a calendar date right next to this phrase, and the two
+ * have to agree. Counting local days against a UTC-formatted date is how you
+ * get "Updated today" beside yesterday's date.
+ */
+function utcDaysBetween(from: Date, to: Date): number {
+  const day = 86_400_000;
+  const startOfDay = (d: Date) =>
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()) / day;
+  return startOfDay(to) - startOfDay(from);
+}
+
+/**
+ * Relative freshness of a release, or null when it should not be shown:
+ * an unparseable date, or one older than STALE_AFTER_DAYS.
+ *
+ * A future date (clock skew between GitHub and the renderer) clamps to today
+ * rather than printing "Updated -1 days ago".
+ */
+export function formatFreshness(latestISO: string, now: Date): string | null {
+  const published = new Date(latestISO);
+  if (Number.isNaN(published.getTime())) {
+    return null;
+  }
+
+  const days = utcDaysBetween(published, now);
+  if (days >= STALE_AFTER_DAYS) {
+    return null;
+  }
+  if (days <= 0) {
+    return 'Updated today';
+  }
+  if (days === 1) {
+    return 'Updated yesterday';
+  }
+  if (days < 7) {
+    return `Updated ${days} days ago`;
+  }
+  if (days < 14) {
+    return 'Updated last week';
+  }
+  return `Updated ${Math.floor(days / 7)} weeks ago`;
+}
+
+/** "April 2026" for the release that started the count. Null if unparseable. */
+export function formatSince(firstISO: string): string | null {
+  const first = new Date(firstISO);
+  if (Number.isNaN(first.getTime())) {
+    return null;
+  }
+  return first.toLocaleDateString('en-US', {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+/**
+ * Reduce a raw releases payload to a count and its endpoints.
+ *
+ * Two filters, each of which would otherwise put a wrong number on the
+ * homepage. The releases live on the WEBSITE repo, which also tags its own
+ * `v6.x` template releases, so only names carrying the app prefix count (the
+ * same rule `/api/github-releases` applies to the release-notes feed). And
+ * drafts are excluded: an authenticated read can see unpublished releases, and
+ * counting one claims a release that nobody can download.
+ *
+ * Returns null rather than a zero count, so a payload that matched nothing
+ * degrades to "no count" instead of asserting the app has never shipped.
+ */
+export function summariseReleases(
+  releases: readonly ReleaseRecord[],
+  prefix: string
+): ReleaseSummary | null {
+  const dated = releases
+    .filter((r) => typeof r?.name === 'string' && r.name.startsWith(prefix) && r.draft !== true)
+    .map((r) => r.published_at ?? r.created_at)
+    .filter((at): at is string => typeof at === 'string' && !Number.isNaN(Date.parse(at)))
+    .sort((a, b) => Date.parse(a) - Date.parse(b));
+
+  if (dated.length === 0) {
+    return null;
+  }
+
+  return {
+    total: dated.length,
+    firstISO: dated[0],
+    latestISO: dated[dated.length - 1],
+  };
+}
+
+/** The summary rendered as the strip's strings. */
+export function toCadence(summary: ReleaseSummary, now: Date): ReleaseCadence {
+  return {
+    freshness: formatFreshness(summary.latestISO, now),
+    latestDate: formatReleaseDate(summary.latestISO, summary.latestISO),
+    total: summary.total,
+    since: formatSince(summary.firstISO),
+  };
+}
+
+/**
+ * What the strip shows with no live data: the version's own publication date
+ * out of the config, which release.sh writes in the same commit that publishes
+ * the release. No count and no first-release date, because neither is knowable
+ * offline and an undercount on the homepage is worse than no number at all.
+ */
+export function fallbackReleaseCadence(now: Date = new Date()): ReleaseCadence {
+  const iso = `${config.app.releaseDate}T12:00:00Z`;
+  return {
+    freshness: formatFreshness(iso, now),
+    latestDate: formatReleaseDate(iso, iso),
+    total: null,
+    since: null,
+  };
+}

--- a/components/StructuredData/StructuredData.tsx
+++ b/components/StructuredData/StructuredData.tsx
@@ -22,6 +22,11 @@ const structuredData = {
       url: BASE,
       downloadUrl: config.app.downloadUrl,
       softwareVersion: config.app.version,
+      // The machine-readable half of the homepage release strip. Search
+      // engines get a 403 from /api/github-releases, so the config value
+      // release.sh writes is the only date they can see.
+      dateModified: config.app.releaseDate,
+      releaseNotes: `${BASE}/docs/release-notes`,
       screenshot: `${BASE}/screenshot-overview.png`,
       offers: {
         '@type': 'Offer',

--- a/components/Welcome/Welcome.tsx
+++ b/components/Welcome/Welcome.tsx
@@ -33,10 +33,14 @@ import {
   Stack,
   Text,
   Title,
-  Anchor,
 } from '@mantine/core';
 import config from '@/config';
 import { ShareButtons } from '@/components/ShareButtons/ShareButtons';
+import { ReleaseCadence } from '@/components/ReleaseCadence/ReleaseCadence';
+import {
+  fallbackReleaseCadence,
+  type ReleaseCadence as Cadence,
+} from '@/components/ReleaseCadence/release-cadence';
 import { FAQ } from '../FAQ/FAQ';
 import { ProblemSection } from '../ProblemSection/ProblemSection';
 import { SolutionSection } from '../SolutionSection/SolutionSection';
@@ -200,7 +204,13 @@ const features = [
   },
 ];
 
-export function Welcome() {
+/**
+ * `cadence` is fetched on the server in `app/page.tsx` so the release count
+ * and date ship inside the initial HTML. It defaults to the config-derived
+ * fallback, which keeps the strip rendering in tests and on any path that
+ * mounts the hero without the server fetch.
+ */
+export function Welcome({ cadence = fallbackReleaseCadence() }: { cadence?: Cadence }) {
   // Slideshow is controlled so the custom controls below the stack can
   // drive it (the built-in controls are turned off). Prev/Next wrap
   // around the four screens.
@@ -391,9 +401,12 @@ export function Welcome() {
                 */}
                 {`Free · v${config.app.version} · macOS ${config.app.minMacOS}+ · Universal (Apple Silicon + Intel) · Signed & notarized`}
               </Text>
-              <Anchor href="/docs/release-notes" c="dimmed" size="sm">
-                Release notes
-              </Anchor>
+              {/*
+                Replaces a bare "Release notes" anchor that used to sit here.
+                The strip links to the same page, and two links to it 30px
+                apart was the only thing the old anchor added.
+              */}
+              <ReleaseCadence cadence={cadence} />
             </Stack>
 
             {/* ─── Product Hunt launch badge ─── */}

--- a/components/index.ts
+++ b/components/index.ts
@@ -4,5 +4,6 @@ export { Logo } from './Logo/Logo';
 export { MantineFooter } from './MantineFooter/MantineFooter';
 export { MantineNavBar } from './MantineNavBar/MantineNavBar';
 export { MantineNextraThemeObserver } from './MantineNextraThemeObserver/MantineNextraThemeObserver';
+export { ReleaseCadence } from './ReleaseCadence/ReleaseCadence';
 export { ShareButtons } from './ShareButtons/ShareButtons';
 export { StructuredData } from './StructuredData/StructuredData';

--- a/config/index.ts
+++ b/config/index.ts
@@ -89,6 +89,12 @@ export default {
   },
   app: {
     version: '0.17.1',
+    // Publication date of `version`, UTC, written by release.sh next to the
+    // version itself. It is the OFFLINE FALLBACK for the homepage release
+    // strip: the live date and the release count come from the GitHub
+    // releases API, and this is what the strip shows when that call is
+    // rate-limited or down. Also the JSON-LD `dateModified`.
+    releaseDate: '2026-08-28',
     // 15.6, not 15.0: it is the pbxproj MACOSX_DEPLOYMENT_TARGET and the
     // appcast's sparkle:minimumSystemVersion. Only StructuredData reads this,
     // so a wrong value here is invisible on the page and still published to


### PR DESCRIPTION
Port of findergit-website#53, where the design and the Codex review already happened. The hero printed the version and said nothing about **when** — the half that answers "is this still being worked on".

```
   Free · v0.17.1 · macOS 15.6+ · Universal (Apple Silicon + Intel) · Signed & notarized
              ╭─────────────────────────────────────────╮
              │   ● Updated 3 days ago                  │
              │   42 releases since May 2026 · What's new │
              ╰─────────────────────────────────────────╯
```

## Netfox earns this more than FinderGit does

| | Netfox | FinderGit |
|---|---|---|
| Releases | 42 | 47 |
| First → latest | 17 May → 28 Aug | 15 Apr → 31 Aug |
| **Last 30 days** | **9** | 6 |
| Last 90 days | 32 | 33 |

On recent pace this site has the better story, and it was the one left out of the first round.

The **count** is what carries the signal, not the date: a bare date decays, so past 60 days the relative phrase is suppressed and the strip states the plain date rather than advertising the gap above the fold. The total only ever goes up.

## Where the numbers come from

**Server-side, not through `/api/github-releases`.** That route slices to the three releases the notes page renders, so it cannot produce a total, and it answers `403` to any user agent that looks like a crawler — exactly who should see a freshness signal. A client fetch would also keep both numbers out of the initial HTML.

**Deliberately unauthenticated**, even where `GITHUB_TOKEN` is set: an authenticated read can see drafts, and a draft is a release nobody can download. `revalidate = 3600` keeps it to roughly one request an hour and is what stops `Updated 3 days ago` freezing at release day.

Two filters that would otherwise publish a wrong number: only names carrying `appReleaseNamePrefix` count, so the `v6.x` template releases sharing this repo are excluded; and drafts are dropped. A payload matching nothing returns `null`, never `0` — `0 releases since …` would say the app has never shipped.

`config.app.releaseDate` is the offline fallback and the JSON-LD `dateModified`. **Netfox/chore/website-release-date** writes it going forward; until that merges the value is correct but static, and it only surfaces when the API is unreachable.

## What the port needed, and what it did not

The component is byte-identical to the sibling's apart from the `User-Agent` string: repo, name prefix and version all come from `@/config`, and the **`What's new` link picks up Netfox's orange straight from the theme** with no per-site tweak.

What did need adapting was the test data. Fixtures were retimed to real Netfox releases, and **0.16.6 turned out to be a better example of the `created_at` trap than anything on the other site** — published 20 August against a tag commit from 5 August, fifteen days apart. Dating it by `created_at` would file it behind four releases that actually shipped earlier.

Also replaced: the standalone "Release notes" anchor, which pointed at the page the strip now links to.

## Verified

- Production build: `42` and `May 2026` are in the **prerendered** HTML and match `gh release list`; `/` builds static with `Revalidate 1h`; `dateModified` reads `2026-08-28`.
- `Updated 3 days ago` against a 28 August publication — independently checked, and the **first time the plural-days branch** of the ladder has run on either site.
- Looked at in both colour schemes; the pill holds 308×61 with no horizontal overflow at a 500px viewport.
- 34 tests green (30 of them new), `tsc --noEmit`, oxlint and stylelint clean.

**Pre-existing, not touched:** `components/RoadmapTimeline/RoadmapTimeline.tsx` fails `oxfmt --check` on `main` too. Left alone so this branch stays one topic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a homepage release-cadence strip showing freshness, release counts, first-release timing, and a link to release notes.
  * Added a live status indicator with reduced-motion support.
  * Release information updates automatically and includes an offline fallback.
  * Enhanced structured metadata with the latest release date and release-notes link.

* **Bug Fixes**
  * Improved handling of unavailable or incomplete release data without disrupting the homepage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->