### PR TITLE
docs: stop calling a shipped module upcoming, and count the copies properly

### DIFF
--- a/components/RoadmapTimeline/RoadmapTimeline.tsx
+++ b/components/RoadmapTimeline/RoadmapTimeline.tsx
@@ -22,11 +22,29 @@ const tierColor: Record<Tier, string> = {
   Backlog: 'gray',
 };
 
-// The same module list lives in two other places and each drifts on its own:
-// content/tools/optimization.mdx, and the app's own Optimization screen
-// (Netfox/OptimizationSection.swift). Wi-Fi diagnostics shipped in 0.17.0 and
-// went on reading "Up next" in the app for a full release, because nothing
-// connects the three. Move one, move all three.
+// SIX places name these modules, not three. The count in this note used to
+// say three -- here, the RoadmapTimeline component, and the app's own
+// Optimization screen. Grepping the module names across both repos on
+// 2026-09-03 found the rest:
+//
+//   1. Netfox/OptimizationSection.swift   the canonical list
+//   2. Netfox/HomeSection.swift   the Overview's roadmap teaser
+//   3. content/tools/optimization.mdx this table
+//   4. components/RoadmapTimeline/RoadmapTimeline.tsx
+//   5. content/index.mdx  "the upcoming module wave"
+//   6. content/getting-started.mdxthe same phrase
+//
+// Two of them (2, and 5 with 6) were still calling Wi-Fi diagnostics
+// upcoming a release after it shipped. content/keyboard-shortcuts.mdx makes
+// the same claim without naming anything, so it cannot drift on names but
+// does go stale on the premise.
+//
+// A comment enumerating the copies is itself a copy, and this one drifted
+// the same way. Nothing here derives from a machine-readable fact, so the
+// only net that finds them all is a grep for the module NAMES across both
+// repos, run whenever one of them moves. A shipped module leaves the app's
+// list entirely, since that one answers "what is not built yet" rather than
+// "what happened".
 const modules: { icon: ReactNode; title: string; tier: Tier; body: ReactNode }[] = [
   {
     icon: <IconPlugConnected size={18} />,

--- a/content/getting-started.mdx
+++ b/content/getting-started.mdx
@@ -34,7 +34,7 @@ Netfox is organised as a left tool sidebar with five entries, mirroring the way 
 | [**Wi-Fi**](/docs/tools/wifi) | Every wireless network your Mac can see, signal history, channel, security |
 | [**Devices**](/docs/tools/devices) | The LAN device list, with a detail panel per device |
 | [**Security**](/docs/tools/security) | Port-probe results + risk badges per reachable device, with a one-click *Scan All Devices* |
-| [**Optimization**](/docs/tools/optimization) | Preview of the upcoming module wave (Wi-Fi diagnostics, Link, Bandwidth) |
+| [**Optimization**](/docs/tools/optimization) | Preview of the module wave still to come (Link, Bandwidth, Speed test) |
 
 Switch tools with the sidebar or with <Kbd>⌘</Kbd> <Kbd>1</Kbd> through <Kbd>⌘</Kbd> <Kbd>5</Kbd>. Each tool has its own deep-dive in the docs — click any row above for the full reference.
 

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -21,7 +21,7 @@ The app is organised as five focused tools you switch between from the left side
 - [**Wi-Fi**](/docs/tools/wifi) — every Wi-Fi network your Mac can see, with live signal-strength history, channel, band, and security mode
 - [**Devices**](/docs/tools/devices) — the full LAN device list, with a detail panel per device showing identity, network, history, and open services
 - [**Security**](/docs/tools/security) — port-probe results and risk badges for every reachable device, plus a one-click *Scan All Devices*
-- [**Optimization**](/docs/tools/optimization) — preview of the upcoming module wave (Wi-Fi diagnostics → Link diagnostics → Bandwidth monitor)
+- [**Optimization**](/docs/tools/optimization) — preview of the module wave still to come (Link diagnostics → Bandwidth monitor → Speed test)
 
 Each tool reads from the same shared device store, so a finding in one shows up everywhere it's relevant. And when you don't need the full window, the [**menu bar popover**](/docs/menu-bar) keeps the essentials — devices online, risk, public IP, live traffic — one click away.
 

--- a/content/tools/optimization.mdx
+++ b/content/tools/optimization.mdx
@@ -15,12 +15,29 @@ This tool intentionally doesn't ship functionality yet. Each module under it nee
 
 ## What's coming
 
-{/* This list exists THREE times and each copy drifts on its own: here, in
-    components/RoadmapTimeline/RoadmapTimeline.tsx, and in the app itself
-    (Netfox/OptimizationSection.swift). Wi-Fi diagnostics shipped in 0.17.0
-    and stayed "Up next" in all three for a full release. Move one, move all
-    three -- and a shipped module leaves the app's list entirely, since that
-    one answers "what is not built yet" rather than "what happened". */}
+{/* SIX places name these modules, not three. The count in this note used to
+    say three -- here, the RoadmapTimeline component, and the app's own
+    Optimization screen. Grepping the module names across both repos on
+    2026-09-03 found the rest:
+
+      1. Netfox/OptimizationSection.swift   the canonical list
+      2. Netfox/HomeSection.swift           the Overview's roadmap teaser
+      3. content/tools/optimization.mdx     this table
+      4. components/RoadmapTimeline/RoadmapTimeline.tsx
+      5. content/index.mdx                  "the upcoming module wave"
+      6. content/getting-started.mdx        the same phrase
+
+    Two of them (2, and 5 with 6) were still calling Wi-Fi diagnostics
+    upcoming a release after it shipped. content/keyboard-shortcuts.mdx makes
+    the same claim without naming anything, so it cannot drift on names but
+    does go stale on the premise.
+
+    A comment enumerating the copies is itself a copy, and this one drifted
+    the same way. Nothing here derives from a machine-readable fact, so the
+    only net that finds them all is a grep for the module NAMES across both
+    repos, run whenever one of them moves. A shipped module leaves the app's
+    list entirely, since that one answers "what is not built yet" rather than
+    "what happened". */}
 
 | Module | Status | Notes |
 |---|---|---|


### PR DESCRIPTION
Two pages still described the **"upcoming module wave"** with Wi-Fi diagnostics in it. It shipped in v0.17.0 — and it did not ship into Optimization, it lives in the Wi-Fi tool. So both sentences were wrong twice over, on the home page and the getting-started table: the two pages a first-time reader actually opens.

## The note explaining where the copies live was one of the copies

It said the list exists three times. A grep for the module names across both repos found **six**:

| # | where | |
|---|---|---|
| 1 | `Netfox/OptimizationSection.swift` | the canonical list |
| 2 | `Netfox/HomeSection.swift` | the Overview's roadmap teaser — *was stale, fixed in the app* |
| 3 | `content/tools/optimization.mdx` | the status table |
| 4 | `components/RoadmapTimeline/RoadmapTimeline.tsx` | the timeline |
| 5 | `content/index.mdx` | **fixed here** |
| 6 | `content/getting-started.mdx` | **fixed here** |

`content/keyboard-shortcuts.mdx` makes the same claim without naming anything, so it cannot drift on names but does go stale on the premise. It is in the inventory rather than edited.

Both notes now carry that inventory and the reason a note cannot be the net: **nothing here derives from a machine-readable fact**, so the only thing that finds them is a grep for the module names, run whenever one of them moves. The note drifted for exactly that reason — whoever added a list did not know to come update it.

## What is deliberately untouched

**"Link diagnostics — Up next"**, in both the table and the timeline. It is still true: the module is on `main` and there is no DMG. It changes in the release motion along with the rest of the status table, rather than being made wrong early — the failure this PR exists to fix is a page claiming something that is not so yet.

## Verified

- `npx jest` on `main` first, then on the branch: **34 tests, 5 suites, green both times**. (This repo's twin shipped a suite that had never passed, so a green run of one's own proves nothing until `main` is known good.)
- `next build` compiles, and the new sentence is in the prerendered HTML while the old one is not — checked against `.next/server`, not against the source. Ten stale hits under `.next/dev` are leftovers from an old `next dev`, which is worth knowing before anyone greps the whole `.next` tree and concludes the change did not land.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Optimization tool documentation to reflect the upcoming module sequence: Link diagnostics, Bandwidth monitor, and Speed test.
  - Replaced references to Wi‑Fi diagnostics with Speed test in the getting-started and documentation index pages.
  - Clarified wording around the remaining upcoming module wave.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->