### PR TITLE
docs: link diagnostics shipped in v0.18.0

### DIFF
--- a/components/RoadmapTimeline/RoadmapTimeline.tsx
+++ b/components/RoadmapTimeline/RoadmapTimeline.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { IconBolt, IconChartArea, IconPlugConnected, IconWifi } from '@tabler/icons-react';
+import { IconBolt, IconChartArea } from '@tabler/icons-react';
 import { Badge, Group, Text, Timeline } from '@mantine/core';
 
 /**
@@ -47,22 +47,9 @@ const tierColor: Record<Tier, string> = {
 // "what happened".
 const modules: { icon: ReactNode; title: string; tier: Tier; body: ReactNode }[] = [
   {
-    icon: <IconPlugConnected size={18} />,
-    title: 'Link diagnostics',
-    tier: 'Up next',
-    body: (
-      <>
-        Physical-layer health. What your Ethernet port negotiated against what it is capable of
-        &mdash; a 10-gigabit port settling for 1 is worth knowing, and the switch or the cable is
-        usually why &mdash; plus link error counters and route latency. For people who plug their
-        Mac in and want to know whether they are getting what they paid for.
-      </>
-    ),
-  },
-  {
     icon: <IconChartArea size={18} />,
     title: 'Bandwidth monitor',
-    tier: 'Then',
+    tier: 'Up next',
     body: (
       <>
         Per-device traffic accounting in real time. The biggest single lift on the roadmap because
@@ -76,7 +63,7 @@ const modules: { icon: ReactNode; title: string; tier: Tier; body: ReactNode }[]
   {
     icon: <IconBolt size={18} />,
     title: 'Speed test',
-    tier: 'Backlog',
+    tier: 'Then',
     body: (
       <>
         A built-in speed test (download / upload / latency / jitter / packet loss). Nice to have,

--- a/content/tools/optimization.mdx
+++ b/content/tools/optimization.mdx
@@ -42,9 +42,9 @@ This tool intentionally doesn't ship functionality yet. Each module under it nee
 | Module | Status | Notes |
 |---|---|---|
 | **Wi-Fi diagnostics** | Shipped in v0.17.0 | Channel congestion, neighbour-AP interference, hidden network detection, and a plain-English verdict on whether your Wi-Fi is the problem — built into today's [Wi-Fi](/docs/tools/wifi) tool |
-| **Link diagnostics** | Up next | Physical-layer health: what your Ethernet port negotiated against what it can do — a 10-gigabit port settling for 1 is worth knowing, and the switch or the cable is usually why — plus link error counters and route latency |
-| **Bandwidth monitor** | Then | Per-device traffic accounting in real time. Needs a privileged background helper to read packet metadata — the biggest single lift on the roadmap. The menu bar's [traffic chart](/docs/menu-bar#live-traffic) already covers your own Mac |
-| **Speed test** | Backlog | Built-in download / upload / latency / jitter / packet-loss benchmark |
+| **Link diagnostics** | Shipped in v0.18.0 | Physical-layer health: what your Ethernet port negotiated against what it can do — a 10-gigabit port settling for 1 is worth knowing, and the switch or the cable is usually why — plus link error counters and route latency, split into your own first hop and everything past your router. Built into the [Overview](/docs/tools/overview#link) |
+| **Bandwidth monitor** | Up next | Per-device traffic accounting in real time. Needs a privileged background helper to read packet metadata — the biggest single lift on the roadmap. The menu bar's [traffic chart](/docs/menu-bar#live-traffic) already covers your own Mac |
+| **Speed test** | Then | Built-in download / upload / latency / jitter / packet-loss benchmark |
 
 **The order is the promise, not a version number.** Each module lands in whatever version is current when it's ready, so this table tracks status rather than a target — a number written here ages badly the moment a release slips or arrives early. See the [Roadmap](/docs/roadmap) for the longer narrative and what comes after these.
 


### PR DESCRIPTION
The two copies that track module status, advanced together as the note beside each of them says to. 0.18.0 went out today.

- The **table** keeps shipped modules with their version, so it reads as a status board: link diagnostics now says *Shipped in v0.18.0* and links to the [Overview](/docs/tools/overview#link) page where the panel actually lives.
- The **timeline** lists what is still ahead, so a shipped module leaves it entirely. Bandwidth monitor moves up to *Up next* and the speed test to *Then*, in both places.

### The timeline was still importing `IconWifi`, unused

It is the icon the **Wi-Fi diagnostics** entry used before that module shipped and left the list — so the very drift the note in that file warns about had already left a dead import behind, months ago, and nothing had noticed. Removed, along with the plug icon this change orphans.

Small, and the point is what it says about the mechanism: a comment telling the next person to move all the copies does not tell them to clean up after the move.

### Verified

`Link diagnostics` no longer appears on the built roadmap page; `Shipped in v0.18.0` does. 34 tests green, oxlint clean, `next build` compiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Roadmap Updates**
  * Removed “Link diagnostics” from the roadmap timeline.
  * Marked “Link diagnostics” as shipped in version 0.18.0 with a link to its overview.
  * Moved “Bandwidth monitor” to the next planned module.
  * Moved “Speed test” from Backlog to the upcoming roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->