### PR TITLE
fix: the 0.18.0 notes understated the translation count

### DIFF
--- a/public/release-notes/0.18.0.html
+++ b/public/release-notes/0.18.0.html
@@ -127,7 +127,7 @@
 <li><strong>Counters are read at 64 bits.</strong> The 32-bit form wraps, and a wrapped counter turns a healthy link into an astronomical number on a screen. A counter that goes backwards is refused rather than subtracted.</li>
 <li><strong>The threshold for a slow first hop is a named constant with its calibration beside it</strong> — about eight times the floor measured on one machine, which is "generous enough not to cry wolf" rather than "the boundary of healthy".</li>
 <li><strong>Nothing new is asked of you.</strong> The physical link, the radio and the counters are all read without a privilege, a permission prompt or a helper. The only traffic this feature generates is the latency measurement, and that is behind the switch you already have.</li>
-<li><strong>Six languages, in step.</strong> 858/858 in Italian, French, German, Spanish, Portuguese and Dutch, plus 89/89 in the framework catalog.</li>
+<li><strong>Six languages, in step.</strong> 864/864 in Italian, French, German, Spanish, Portuguese and Dutch, plus 89/89 in the framework catalog.</li>
 <li><strong>774 tests, green.</strong></li>
 </ul>
 <h2>Install</h2>


### PR DESCRIPTION
They said **858/858**. The six What's New bullets landed after the notes were written, taking the app catalogue to **864** — so the number was true when it was typed and false by the time it shipped.

Small, and worth a commit rather than a shrug: this page is what Sparkle renders inside the update prompt, so it is the copy most users actually read, and the whole point of quoting a coverage number is that it can be trusted.

The GitHub release body is already corrected (`gh release edit`); this is the hosted page that goes with it.