### PR TITLE
Docs: what a TLS port's certificate says (hold for the release)

### DIFF
--- a/content/roadmap.mdx
+++ b/content/roadmap.mdx
@@ -22,7 +22,7 @@ Netfox **{config.app.version}** is live. The current build covers:
 - **Security** — port probe + risk badges, network-wide Smart Scan, Risk Inspector, scheduled scans, user-defined **custom ports** (now a tidy list editor), and an opt-in **Full Scan** that sweeps a wider port range on any device, with live progress.
 - **Public IP & VPN awareness** — shows your network's outward face and whether traffic is tunnelled.
 - **Demo Mode** — a one-keystroke privacy mask for screenshots and demos.
-- **Service inspection** — tap an open port to see what's actually answering: the product behind it, a read-only peek at what it announces, posture verdicts for exposed databases, a hand-off to the right system app, and a built-in web viewer locked to the one device you're inspecting.
+- **Service inspection** — tap an open port to see what's actually answering: the product behind it, a read-only peek at what it announces, posture verdicts for exposed databases, a hand-off to the right system app, and a built-in web viewer locked to the one device you're inspecting, and what a TLS port's certificate says about itself — who it is for, who vouches for it, and whether it has expired or signs for itself.
 - **Overview dashboard** — the landing surface that summarises everything above at a glance, with Devices and Risk shown as at-a-glance ring gauges.
 - **Your language** — the interface follows macOS across English, Italian, French, German, Spanish, Portuguese and Dutch.
 - **Notch quick view** — a Dynamic-Island-style overlay under the MacBook notch with your network at a glance.

--- a/content/tools/devices.mdx
+++ b/content/tools/devices.mdx
@@ -186,6 +186,30 @@ A database reachable **with no password** is the one you want to catch: right no
 Live inspection is **off by default** and strictly read-only — Netfox opens an outgoing connection only when you ask it to (or, with **Inspect automatically during scans**, as part of a scan you started), and never sends a password or a command. It's suppressed entirely in [Demo Mode](/docs/settings#privacy).
 </Callout>
 
+### Reading a certificate
+
+A port that speaks encrypted from the first byte — 443, 8443, a mail port like 993 or 995 — presents a **certificate** before anything else happens. It says who the server claims to be, who vouches for that claim, and until when. The Overview tab gains a **Read certificate** button for those ports, behind the same Live inspection switch.
+
+What comes back is three lines and, when there is something to say, a warning:
+
+- **Issued to** — the name the certificate is for. On a home device this is usually the device's own hostname.
+- **Issued by** — who signed it. A public authority, or the device itself.
+- **Expires** — the date it stops being valid.
+
+Two of those combinations are worth knowing about, and Netfox names them rather than leaving you to compare dates and strings:
+
+**It has expired.** Browsers and apps will refuse it or nag about it, and the fix is usually a renewal nobody remembers to do. A NAS or a camera quietly serving an expired certificate is a common find on a home network.
+
+**It is signed by itself.** The certificate vouches for nothing except its own claim, because whoever issued it *is* the server. That is completely normal on a home device that generated its own on first boot, and it is worth a second look anywhere you did not expect it — a self-signed certificate is exactly what something impersonating a device on your network would also present.
+
+Netfox also flags a certificate that is **not valid yet**, which almost always means the clock on the device is wrong rather than anything sinister, and one that **expires within three weeks**, so a renewal can happen before something breaks.
+
+<Callout type="info">
+Netfox reads the certificate and then **deliberately hangs up without completing the connection**. It has what it came for by then, so there is no reason to finish: nothing further is exchanged and no session is established. Reading is not the same as trusting — an expired or self-signed certificate is precisely what this is for, so Netfox looks at what the server presents without judging whether to accept it.
+</Callout>
+
+Certificate details are hidden in [Demo Mode](/docs/settings#privacy), for the same reason hostnames are: the name on a certificate is very often the name of the device.
+
 ## Local Services — what's listening on your own Mac
 
 Select **This Mac** in the device list and you get a tab no other device has: **Local Services**.
@@ -286,5 +310,6 @@ When [Demo Mode](/docs/settings#privacy) is on:
 - MAC addresses lose the last three octets (vendor OUI survives)
 - IPv6 addresses lose everything past the first hextet
 - IPv4 stays visible — RFC 1918 ranges don't leak anything network-specific
+- Certificate details are hidden entirely — the name on a certificate is usually the device's own
 
 The render-only masking is enough for safe screenshots; the underlying store is never touched.


### PR DESCRIPTION
Docs for the certificate card (Netfox#279), written now rather than after the release — which is the point in the process where this step gets skipped.

**⚠️ Not for merging yet.** The feature is unreleased. Merging this would put documentation live for a card nobody has. It rides the release that ships #279.

## The gap was bigger than "a page to update"

The site had **no page describing what the port inspector reads** — a line in the roadmap and a mention in Settings, nothing else. So the card would have shipped invisible, which is the failure the docs-sync rule exists to prevent.

The new section sits beside *Reading a non-web service*, under the existing **Looking inside a service** heading: same affordance, same Live inspection switch, so a reader meets it where they already are.

## Three things the app cannot say on screen

The card has room for one warning line. The page has room for the reasoning, and these are the parts a reader is entitled to:

- **why self-signed is not simply bad** — normal on a home device that generated its own on first boot, and worth a second look anywhere you did not expect it, because a self-signed certificate is also what something impersonating a device would present;
- **that "not valid yet" is almost always a wrong clock** rather than anything sinister;
- **that Netfox reads the certificate and then deliberately hangs up without completing the connection.** It has what it came for, so nothing further is exchanged and no session is established. That is the design the code review arrived at, and it is the honest answer to "so it connects to my devices?".

## Two smaller corrections in the same pass

**Demo Mode's list gains the certificate.** That list is explicit — hostnames, MAC octets, IPv6 — so leaving it out would have read as *certificates still show*, which is the opposite of true.

**The roadmap's Service inspection line** now names the certificate among what the feature covers, rather than describing a smaller feature than the one that ships.

## Verified

`next build` green, and the prose is in the **prerendered HTML** rather than only in the source — checked on `.next/server/app/docs/tools/devices.html` for four distinctive phrases, since content that only exists in a JS chunk reads as a failed deploy.

No screenshot: the card cannot be photographed without a LAN device serving TLS, and the release's own scripted shoot is where that belongs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the roadmap to mention TLS certificate inspection during service inspection.
  - Added guidance for viewing certificate identities, issuers, validity dates, and security warnings on encrypted ports.
  - Documented connection termination behavior and clarified that certificate details are hidden in Demo Mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->